### PR TITLE
add docs

### DIFF
--- a/.changeset/tanstack-redirect-docs.md
+++ b/.changeset/tanstack-redirect-docs.md
@@ -1,0 +1,9 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Add documentation for avoiding redirect loops with frameworks that handle URL localization themselves (e.g., TanStack Router).
+
+- Added JSDoc example in `paraglideMiddleware()` explaining when to use the original request vs the modified request
+- Added troubleshooting section in SSR docs explaining the redirect loop issue and solution
+- Updated TanStack Start example README with an important callout about using the original request

--- a/docs-api/server/type/-internal-.md
+++ b/docs-api/server/type/-internal-.md
@@ -2,7 +2,7 @@
 
 > **paraglideMiddleware**\<`T`\>(`request`, `resolve`, `callbacks?`): `Promise`\<`Response`\>
 
-Defined in: [server/middleware.js:64](https://github.com/opral/monorepo/tree/main/src/compiler/server/middleware.js)
+Defined in: [server/middleware.js:100](https://github.com/opral/monorepo/tree/main/src/compiler/server/middleware.js)
 
 Server middleware that handles locale-based routing and request processing.
 
@@ -38,7 +38,11 @@ The incoming request object
 
 (`args`) => `T` \| `Promise`\<`T`\>
 
-Function to handle the request
+Function to handle the request. The callback receives:
+  - `request`: A modified request with a delocalized URL when the URL strategy is used (e.g., `/fr/about` → `/about`).
+     If your framework handles URL localization itself (e.g., TanStack Router's `rewrite` option), use the original
+     request instead to avoid redirect loops.
+  - `locale`: The determined locale for this request.
 
 #### callbacks?
 
@@ -57,7 +61,7 @@ Callbacks to handle events from middleware
 ```typescript
 // Basic usage in metaframeworks like NextJS, SvelteKit, Astro, Nuxt, etc.
 export const handle = async ({ event, resolve }) => {
-  return serverMiddleware(event.request, ({ request, locale }) => {
+  return paraglideMiddleware(event.request, ({ request, locale }) => {
     // let the framework further resolve the request
     return resolve(request);
   });
@@ -67,7 +71,7 @@ export const handle = async ({ event, resolve }) => {
 ```typescript
 // Usage in a framework like Express JS or Hono
 app.use(async (req, res, next) => {
-  const result = await serverMiddleware(req, ({ request, locale }) => {
+  const result = await paraglideMiddleware(req, ({ request, locale }) => {
     // If a redirect happens this won't be called
     return next(request);
   });
@@ -81,11 +85,42 @@ app.use(async (req, res, next) => {
 // one request could leak into another concurrent request.
 export default {
   fetch: async (request) => {
-    return serverMiddleware(
+    return paraglideMiddleware(
       request,
       ({ request, locale }) => handleRequest(request, locale),
       { disableAsyncLocalStorage: true }
     );
   }
 };
+```
+
+```typescript
+// Usage with frameworks that handle URL localization/delocalization themselves
+//
+// Some frameworks like TanStack Router handle URL localization and delocalization
+// themselves via their own rewrite APIs (e.g., `rewrite.input`/`rewrite.output`).
+//
+// When the framework handles this, the middleware's URL delocalization is not needed.
+// Using the modified `request` from the callback would cause a redirect loop because
+// both the middleware and the framework would attempt to delocalize the URL.
+//
+// Solution: Pass the original request to the handler instead of the modified one.
+// The middleware still handles locale detection, cookies, and AsyncLocalStorage context.
+//
+// ❌ WRONG - causes redirect loop when framework handles URL rewriting:
+// paraglideMiddleware(req, ({ request }) => handler.fetch(request))
+//
+// ✅ CORRECT - use original request when framework handles URL localization:
+// paraglideMiddleware(req, () => handler.fetch(req))
+
+import { paraglideMiddleware } from './paraglide/server.js'
+import handler from '@tanstack/react-start/server-entry'
+
+export default {
+  fetch(req: Request): Promise<Response> {
+    // TanStack Router handles URL rewriting via deLocalizeUrl/localizeUrl
+    // so we pass the original `req` instead of the modified `request`
+    return paraglideMiddleware(req, () => handler.fetch(req))
+  },
+}
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -13,7 +13,7 @@ imports:
 [![Closed github issues](https://img.shields.io/github/issues-closed/opral/paraglide-js?logo=github&color=purple)](https://github.com/opral/inlang-paraglide-js/issues)
 [![Monorepo contributors](https://img.shields.io/github/contributors/opral/monorepo?logo=github)](https://github.com/opral/monorepo/graphs/contributors)
 
-[<img src="https://cdn.jsdelivr.net/gh/opral/monorepo@latest/inlang/packages/paraglide/paraglide-js/assets/header.png" alt="Dead Simple i18n. Typesafe, Small Footprint, Treeshsakeable Messages, IDE Integration, Framework Agnostic" width="10000000px" />](https://www.youtube.com/watch?v=-YES3CCAG90)
+[<img src="https://cdn.jsdelivr.net/gh/opral/monorepo@latest/inlang/packages/paraglide/paraglide-js/assets/header.png" alt="Dead Simple i18n. Typesafe, Small Footprint, Tree-shakeable Messages, IDE Integration, Framework Agnostic" width="10000000px" />](https://www.youtube.com/watch?v=-YES3CCAG90)
 
 # Why Paraglide?
 

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -21,7 +21,7 @@ npx gitpick TanStack/router/tree/main/examples/react/start-i18n-paraglide start-
 npx @inlang/paraglide-js@latest init
 ```
 
-2. Add the vite plugin to your `vite.config.ts`:
+2. Add the Vite plugin to your `vite.config.ts`:
 
 ```diff
 import { defineConfig } from 'vite'
@@ -76,17 +76,21 @@ const router = createRouter({
 
 In `server.ts` intercept the request with the paraglideMiddleware.
 
+> **Important:** Since TanStack Router handles URL localization/delocalization via its `rewrite` option, you must pass the original `req` to the handler instead of the modified `request` from the callback. Using the modified request would cause a redirect loop because both the middleware and the router would attempt to delocalize the URL. The middleware still handles locale detection, cookies, and AsyncLocalStorage context.
+
 ```ts
 import { paraglideMiddleware } from './paraglide/server.js'
 import handler from '@tanstack/react-start/server-entry'
 export default {
   fetch(req: Request): Promise<Response> {
+    // Pass original `req` - NOT the modified `request` from the callback
+    // TanStack Router handles URL rewriting via deLocalizeUrl/localizeUrl
     return paraglideMiddleware(req, () => handler.fetch(req))
   },
 }
 ```
 
-In `__root.tsx` change the html lang attribute to the current locale.
+In `__root.tsx` change the HTML lang attribute to the current locale.
 
 ```tsx
 import { getLocale } from '../paraglide/runtime.js'
@@ -125,7 +129,7 @@ export const Route = createRootRoute({
 });
 ```
 
-## Typesafe translated pathnames
+## Type-safe translated pathnames
 
 If you don't want to miss any translated path, you can create a `createTranslatedPathnames` function and pass it to the vite plugin.
 


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/576

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds guidance to prevent redirect loops when frameworks perform their own URL localization.
> 
> - Expands `paraglideMiddleware()` JSDoc with instructions/examples to pass the original request when using frameworks like TanStack Router that rewrite URLs
> - Updates SSR docs with a troubleshooting section on redirect loops, corrects typos, and uses `new Response(...)` in examples
> - Revises TanStack Start example README to call out using the original `req` and shows proper server integration
> - Minor copy/typo fixes in `docs/introduction.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e75e2a3ebdb0a66e2a695347843fe063f141262a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->