### PR TITLE
strip source map comment

### DIFF
--- a/.changeset/strip-generated-sourcemaps.md
+++ b/.changeset/strip-generated-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Strip sourcemap references from generated runtime and server outputs to avoid missing map warnings. (https://github.com/opral/paraglide-js/issues/581)

--- a/src/compiler/runtime/create-runtime.ts
+++ b/src/compiler/runtime/create-runtime.ts
@@ -217,5 +217,11 @@ function injectCode(path: string): string {
 	const code = fs.readFileSync(new URL(path, import.meta.url), "utf-8");
 	// Regex to match single-line and multi-line imports
 	const importRegex = /import\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g;
-	return code.replace(importRegex, "").trim();
+	const sourceMapRegex = /\/\/# sourceMappingURL=.*$/gm;
+	const blockSourceMapRegex = /\/\*# sourceMappingURL=.*?\*\//g;
+	return code
+		.replace(importRegex, "")
+		.replace(sourceMapRegex, "")
+		.replace(blockSourceMapRegex, "")
+		.trim();
 }

--- a/src/compiler/server/create-server-file.ts
+++ b/src/compiler/server/create-server-file.ts
@@ -65,5 +65,11 @@ function injectCode(path: string): string {
 	const code = fs.readFileSync(new URL(path, import.meta.url), "utf-8");
 	// Regex to match single-line and multi-line imports
 	const importRegex = /import\s+[\s\S]*?from\s+['"][^'"]+['"]\s*;?/g;
-	return code.replace(importRegex, "").trim();
+	const sourceMapRegex = /\/\/# sourceMappingURL=.*$/gm;
+	const blockSourceMapRegex = /\/\*# sourceMappingURL=.*?\*\//g;
+	return code
+		.replace(importRegex, "")
+		.replace(sourceMapRegex, "")
+		.replace(blockSourceMapRegex, "")
+		.trim();
 }


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/581

**Why this happened**

We recently enabled TypeScript sourcemap emission in tsconfig.json (sourceMap: true). That causes the compiled files in dist/ to include //# sourceMappingURL=... comments. Our compiler then assembles runtime.js and server.js by inlining those dist/ snippets, so the sourcemap comments were copied into the generated outputs. The corresponding .map files are not emitted into the consumer’s output directory, so Vite attempts to load them and logs missing‑file warnings.

**Fix**

strip sourceMappingURL comments during inlining so generated outputs don’t reference missing maps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents missing sourcemap warnings by removing source map references from generated outputs.
> 
> - Strip `//# sourceMappingURL` (line and block) during inlining via `injectCode` in `create-runtime.ts` and `create-server-file.ts`
> - Add regression test in `compile.test.ts` ensuring `runtime.js` and `server.js` omit sourcemap references
> - Add patch changeset entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be10228952c129216d9e8d24b1ba8f8b39aa7523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->