### PR TITLE
Investigate Paraglide locale limit and performance

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -36,8 +36,21 @@ If you are looking for a benchmark, check out the [interactive benchmark](/m/ger
 | **Variants** [ℹ️](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/variants)</sup>                    | [✅ Yes](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/variants)                                                                | ❌ No                                                                                                            | ❌ No                                                                                            |
 | **Multi-tenancy** [ℹ️](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/multi-tenancy)</sup>          | [✅ Yes](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/multi-tenancy)                                                           | ❌ No                                                                                                            | ❌ No                                                                                            |
 | **Message syntax agnostic** [ℹ️](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/file-formats)</sup> | [✅ Via inlang plugins](https://inlang.com/c/plugins)                                                                                      | [✅ Via different backends](https://www.i18next.com/how-to/add-or-load-translations#load-using-a-backend-plugin) | ❌ Only ICU                                                                                      |
-| **Scales well over 15 locales**                                                                               | [🟠 Experimental split locale option](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/benchmark)                                  | [✅ Via HTTP backend](https://github.com/i18next/i18next-http-backend)                                           | ❌ No                                                                                            |
+| **Lazy locale loading** [ℹ️](#lazy-locale-loading)                                                            | [🟠 Experimental](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/benchmark)                                                      | [✅ HTTP backend](https://github.com/i18next/i18next-http-backend)                                               | ❌ No                                                                                            |
 | **Component interpolation**                                                                                   | [❌ Upvote issue #240](https://github.com/opral/inlang-sdk/issues/240)                                                                     | [🟠 Only for React](https://react.i18next.com/legacy-v9/trans-component)                                         | [🟠 Only for React](https://formatjs.github.io/docs/react-intl/components/#rich-text-formatting) |
+
+### Lazy locale loading
+
+Paraglide compiles messages into functions that contain all locales. Lazy locale loading instead fetches only the current locale's messages on-demand.
+
+**When does this matter?**
+
+Under ~20 locales, tree-shaking unused messages outweighs the cost of bundling all locales per message—Paraglide remains more efficient. Beyond ~20 locales, lazy loading may become beneficial depending on your app's message usage patterns.
+
+Paraglide has an [experimental locale splitting option](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/benchmark) for apps that need lazy locale loading.
+
+> [!NOTE]
+> **There is no locale limit in Paraglide.** The library works fine with any number of locales. Lazy loading is an optimization, not a requirement.
 
 ## Further Reading
 


### PR DESCRIPTION
The previous phrasing "Scales well over 15 locales" was misleading users into thinking Paraglide has a hard limit of 15 locales.

Changes:
- Rename feature to "Lazy locale loading" which describes what it actually is
- Add explanatory section clarifying when lazy loading matters
- Explain that under ~20 locales, tree-shaking benefits outweigh bundling all locales per message
- Explicitly state there is no locale limit in Paraglide

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies locale handling in `docs/comparison.md` and removes misleading implications about a 15-locale limit.
> 
> - Replaces the advanced features row "Scales well over 15 locales" with `Lazy locale loading` (Paraglide: experimental; i18next: HTTP backend; React-Intl: not supported)
> - Adds a new "Lazy locale loading" section explaining trade-offs (under ~20 locales, tree-shaking is typically more efficient; beyond that, lazy loading may help) and mentions Paraglide's experimental locale splitting option
> - Explicitly states there is no locale limit in Paraglide
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d16922a83d741c74e8951abcc62a5e5fdb390780. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->