### PR TITLE
Fix Astro middleware docs to forward request into `next()`

### DIFF
--- a/docs/middleware-guide.md
+++ b/docs/middleware-guide.md
@@ -128,7 +128,7 @@ import { paraglideMiddleware } from "./paraglide/server.js";
 import { defineMiddleware } from "astro:middleware";
 
 export const onRequest = defineMiddleware((context, next) => {
-	return paraglideMiddleware(context.request, () => next());
+	return paraglideMiddleware(context.request, ({ request }) => next(request));
 });
 ```
 

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -55,7 +55,7 @@ export default defineConfig({
 import { paraglideMiddleware } from "./paraglide/server.js";
 
 export const onRequest = defineMiddleware((context, next) => {
-+	return paraglideMiddleware(context.request, () => next());
++	return paraglideMiddleware(context.request, ({ request }) => next(request));
 });
 ```
 


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/541

### Motivation
- The Astro middleware example forwarded no arguments to `next()`, which prevented the framework from receiving the de-localized request and caused localized routes to 404.
- The paraglide middleware provides a `{ request }` parameter that must be passed into the framework `next`/handler for proper URLPattern matching.

### Description
- Updated `docs/middleware-guide.md` to call `paraglideMiddleware(context.request, ({ request }) => next(request))` in the Astro example.
- Updated `examples/astro/README.md` to mirror the same change in the example snippet.
- This change is documentation-only and does not modify runtime code.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a3fe814c8326b33511f21dae49e6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ba2d73372f8510ddcfac32f1b77fb83a2a68fbbc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->