### PR TITLE
Prefix locale imports to avoid message name collisions

### DIFF
--- a/.changeset/prefix-locale-imports-to-avoid-collisions.md
+++ b/.changeset/prefix-locale-imports-to-avoid-collisions.md
@@ -1,0 +1,10 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Avoid locale/message name collisions in the locale-modules output structure by prefixing locale imports.
+
+Previously, a locale like `no` could collide with a message key `no`, causing duplicate symbol errors in the generated `messages/_index.js`.
+Now, locale imports are prefixed (e.g. `__no`), keeping message exports intact and avoiding the conflict.
+
+Issue: https://github.com/opral/paraglide-js/issues/492

--- a/src/compiler/output-structure/locale-modules.ts
+++ b/src/compiler/output-structure/locale-modules.ts
@@ -3,8 +3,10 @@ import type { CompiledBundleWithMessages } from "../compile-bundle.js";
 import { toSafeModuleId } from "../safe-module-id.js";
 import { inputsType } from "../jsdoc-types.js";
 
+const localeImportPrefix = "__";
+
 export function messageReferenceExpression(locale: string, bundleId: string) {
-	return `${toSafeModuleId(locale)}.${toSafeModuleId(bundleId)}`;
+	return `${localeImportPrefix}${toSafeModuleId(locale)}.${toSafeModuleId(bundleId)}`;
 }
 
 export function generateOutput(
@@ -18,7 +20,7 @@ export function generateOutput(
 		settings.locales
 			.map(
 				(locale) =>
-					`import * as ${toSafeModuleId(locale)} from "./${locale}.js"`
+					`import * as ${localeImportPrefix}${toSafeModuleId(locale)} from "./${locale}.js"`
 			)
 			.join("\n"),
 		compiledBundles.map(({ bundle }) => bundle.code).join("\n"),


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/492

Avoid message name collisions in the locale-modules output structure by prefixing locale imports. This change ensures that locale names do not conflict with message keys, preventing duplicate symbol errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents locale/message name collisions in generated locale modules.
> 
> - Prefixes locale import identifiers with `__` in `locale-modules.ts` and updates `messageReferenceExpression` to reference `__<locale>.<bundleId>`
> - Adds a test ensuring `import * as __no from "./no.js"` and `messageReferenceExpression("no", "no") === "__no.no"`
> - Includes changeset documenting a patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit deb9877982cf60f2fe82e3b423fdffca2458964b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->