### PR TITLE
Avoid fallback cycles for language-only locales with regional baseLocale

### DIFF
--- a/.changeset/avoid-fallback-cycles-for-language-locales.md
+++ b/.changeset/avoid-fallback-cycles-for-language-locales.md
@@ -4,6 +4,6 @@
 
 Avoid cyclic fallback maps when a language-only locale exists alongside a regional base locale.
 
-Previously, a setup like `locales: ["it", "it-IT"]` with `baseLocale: "it-IT"` could create a fallback cycle (`it → it-IT → it`) and throw a runtime error. The compiler now breaks that cycle by not falling back from the language-only locale to its regional base.
+Previously, a setup like `locales: ["it", "it-IT"]` with `baseLocale: "it-IT"` could create a fallback cycle (`it → it-IT → it`) and throw a runtime error. The compiler now breaks that cycle by making the `baseLocale` terminal, so `it-IT` no longer falls back to `it` while `it` still falls back to `it-IT`.
 
 Issue: https://github.com/opral/paraglide-js/issues/544

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -173,8 +173,8 @@ test("fallback map should not create cycles for language-only + regional baseLoc
 
 	expect(hasFallbackCycle(fallbackMap, "it")).toBe(false);
 	expect(hasFallbackCycle(fallbackMap, "it-IT")).toBe(false);
-	expect(fallbackMap["it"]).toBeUndefined();
-	expect(fallbackMap["it-IT"]).toBe("it");
+	expect(fallbackMap["it"]).toBe("it-IT");
+	expect(fallbackMap["it-IT"]).toBeUndefined();
 });
 
 test("emitTsDeclarations generates declaration files", async () => {

--- a/src/compiler/compile-project.ts
+++ b/src/compiler/compile-project.ts
@@ -120,17 +120,13 @@ export function getFallbackMap<T extends string>(
 ): Record<T, T | undefined> {
 	return Object.fromEntries(
 		locales.map((lang) => {
+			if (lang === baseLocale) return [lang, undefined];
 			const fallbackLanguage = lookup(lang, {
 				locales: locales.filter((l) => l !== lang),
 				baseLocale,
 			});
 
 			if (lang === fallbackLanguage) return [lang, undefined];
-			if (fallbackLanguage === baseLocale && baseLocale.startsWith(`${lang}-`)) {
-				// Avoid cycles for language-only locales when baseLocale is regional.
-				// Example: baseLocale "it-IT" with locales ["it", "it-IT"].
-				return [lang, undefined];
-			}
 			else return [lang, fallbackLanguage];
 		})
 	) as Record<T, T | undefined>;


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/544

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents cyclic fallbacks when a language-only locale exists alongside a regional base locale.
> 
> - Update `getFallbackMap` to treat `baseLocale` as terminal (no fallback), breaking cycles like `it ↔ it-IT`
> - Add test verifying no cycles and expected fallbacks for `it`/`it-IT` and others
> - Add changeset for a patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fd28c627fd2d1623c3a722b41723a19289e414f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->