### PR TITLE
Prune async_hooks import when async local storage is disabled

### DIFF
--- a/.changeset/prune-async-hooks-when-disabled.md
+++ b/.changeset/prune-async-hooks-when-disabled.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Prune async_hooks import from generated server output when async local storage is disabled (fixes https://github.com/opral/paraglide-js/issues/539).

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -167,6 +167,27 @@ test("emitReadme includes project path", async () => {
 	expect(output["README.md"]).toContain("Paraglide JS");
 });
 
+// https://github.com/opral/paraglide-js/issues/539
+test("omits async_hooks import when disableAsyncLocalStorage is true", async () => {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				locales: ["en", "de"],
+				baseLocale: "en",
+			},
+		}),
+	});
+
+	const output = await compileProject({
+		project,
+		compilerOptions: { disableAsyncLocalStorage: true },
+	});
+
+	expect(output["server.js"]).not.toContain(
+		'const { AsyncLocalStorage } = await import("async_hooks");'
+	);
+});
+
 // https://github.com/opral/paraglide-js/issues/544
 test("fallback map should not create cycles for language-only + regional baseLocale", () => {
 	const fallbackMap = getFallbackMap(["it", "it-IT", "fr", "fr-FR"], "it-IT");

--- a/src/compiler/create-paraglide.ts
+++ b/src/compiler/create-paraglide.ts
@@ -91,6 +91,9 @@ export async function createParaglide(
 			experimentalMiddlewareLocaleSplitting:
 				args.experimentalMiddlewareLocaleSplitting ??
 				defaultCompilerOptions.experimentalMiddlewareLocaleSplitting,
+			disableAsyncLocalStorage:
+				args.disableAsyncLocalStorage ??
+				defaultCompilerOptions.disableAsyncLocalStorage,
 		},
 	})
 		.replace(`import * as runtime from "./runtime.js";`, "")

--- a/src/compiler/server/middleware.js
+++ b/src/compiler/server/middleware.js
@@ -100,12 +100,7 @@ import * as runtime from "./runtime.js";
  * ```
  */
 export async function paraglideMiddleware(request, resolve, callbacks) {
-	if (!runtime.disableAsyncLocalStorage && !runtime.serverAsyncLocalStorage) {
-		const { AsyncLocalStorage } = await import("async_hooks");
-		runtime.overwriteServerAsyncLocalStorage(new AsyncLocalStorage());
-	} else if (!runtime.serverAsyncLocalStorage) {
-		runtime.overwriteServerAsyncLocalStorage(createMockAsyncLocalStorage());
-	}
+	// %async-local-storage
 
 	const decision = await runtime.shouldRedirect({ request });
 	const locale = decision.locale;
@@ -235,6 +230,9 @@ function createMockAsyncLocalStorage() {
 		},
 	};
 }
+
+// Used in generated server.js when async local storage is disabled.
+void createMockAsyncLocalStorage;
 
 /**
  * The compiled messages for the server middleware.


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/539

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses async local storage handling in generated server code.
> 
> - Injects a `%async-local-storage` marker in `middleware.js` and generates a conditional block in `create-server-file.ts` to either import `async_hooks` or use a mock when `disableAsyncLocalStorage` is set
> - Passes `disableAsyncLocalStorage` through `create-paraglide.ts` into server generation
> - Normalizes generated indentation and preserves middleware bundle injection behavior
> - Adds a test ensuring `server.js` omits `async_hooks` import when disabled
> - Adds a changeset for a minor release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0c566530537fd258f6ebcae48b1a7945a29ba6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->