### PR TITLE
Update @inlang/sdk dependency to version 2.6.2

### DIFF
--- a/.changeset/bright-phones-wink.md
+++ b/.changeset/bright-phones-wink.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Update `@inlang/sdk` to v2.6.2, which removes a file queue settlement that could prevent the compiler from exiting in some environments. See https://github.com/opral/paraglide-js/issues/598.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"dependencies": {
 		"@inlang/recommend-sherlock": "^0.2.1",
-		"@inlang/sdk": "2.6.0",
+		"@inlang/sdk": "2.6.2",
 		"commander": "11.1.0",
 		"consola": "3.4.0",
 		"json5": "2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       '@inlang/sdk':
-        specifier: 2.6.0
-        version: 2.6.0(babel-plugin-macros@3.1.0)
+        specifier: 2.6.2
+        version: 2.6.2(babel-plugin-macros@3.1.0)
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1366,8 +1366,8 @@ packages:
     resolution: {integrity: sha512-cvz/C1rF5WBxzHbEoiBoI6Sz6q6M+TdxfWkEGBYTD77opY8i8WN01prUWXEM87GPF4SZcyIySez9U0Ccm12oFQ==}
     engines: {node: '>=18.0.0'}
 
-  '@inlang/sdk@2.6.0':
-    resolution: {integrity: sha512-f4iVHVXyzOi0CXlXSAT7XPrReLBaVXy/po/qrOPf2OHh+hUwyD1bDx2EYC5KgrZ16z3ylWfqWVuc7o4l7/tuUQ==}
+  '@inlang/sdk@2.6.2':
+    resolution: {integrity: sha512-eOgAX+eQpHvD/H4BMILc4tZ85XviTlwr/51RKkKUHozVVthj5avUPKP+4N4vcTUrqSscl2atTh9NbNTuvoBN0A==}
     engines: {node: '>=18.0.0'}
 
   '@inquirer/external-editor@1.0.3':
@@ -6815,7 +6815,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@inlang/sdk@2.6.0(babel-plugin-macros@3.1.0)':
+  '@inlang/sdk@2.6.2(babel-plugin-macros@3.1.0)':
     dependencies:
       '@lix-js/sdk': 0.4.7(babel-plugin-macros@3.1.0)
       '@sinclair/typebox': 0.31.28


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/598

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency to pick up an upstream fix and prepares a patch release.
> 
> - Upgrade `@inlang/sdk` from `2.6.0` to `2.6.2` and refresh `pnpm-lock.yaml`
> - Add changeset describing a patch for `@inlang/paraglide-js` noting that `2.6.2` removes a file queue settlement that could prevent the compiler from exiting (see issue `#598`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c43effba8aff509c1ad52882630c7f01e7a62ce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->