### PR TITLE
docs: mention ICU MessageFormat 1 plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ m.items_in_cart({ count: 5 }); // "5 items in cart"
 // Works correctly for complex locales (Russian, Arabic, etc.)
 ```
 
-Message format is **plugin-based** — use the default inlang format, or switch to i18next, JSON, or ICU MessageFormat via [plugins](https://inlang.com/c/plugins).
+Message format is **plugin-based** — use the default inlang format, or switch to i18next, JSON, or ICU MessageFormat via [plugins](https://inlang.com/c/plugins). If your team relies on ICU MessageFormat 1 syntax, use the [inlang-icu-messageformat-1 plugin](https://inlang.com/m/p7c8m1d2/plugin-inlang-icu-messageformat-1).
 
 **[Pluralization & Variants Docs →](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/variants)**
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -39,6 +39,8 @@ If you are looking for a benchmark, check out the [interactive benchmark](/m/ger
 | **Lazy locale loading** [ℹ️](#lazy-locale-loading)                                                            | [🟠 Experimental](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/benchmark)                                                      | [✅ HTTP backend](https://github.com/i18next/i18next-http-backend)                                               | ❌ No                                                                                            |
 | **Component interpolation**                                                                                   | [❌ Upvote issue #240](https://github.com/opral/inlang-sdk/issues/240)                                                                     | [🟠 Only for React](https://react.i18next.com/legacy-v9/trans-component)                                         | [🟠 Only for React](https://formatjs.github.io/docs/react-intl/components/#rich-text-formatting) |
 
+Paraglide supports ICU MessageFormat 1 syntax through the [inlang-icu-messageformat-1 plugin](https://inlang.com/m/p7c8m1d2/plugin-inlang-icu-messageformat-1).
+
 ### Lazy locale loading
 
 Paraglide compiles messages into functions that contain all locales. Lazy locale loading instead fetches only the current locale's messages on-demand.


### PR DESCRIPTION
### Motivation
- Clarify that Paraglide JS supports ICU MessageFormat 1 syntax via an inlang plugin so teams that heavily rely on ICU are not discouraged by outdated assumptions.

### Description
- Added a pointer to the `inlang-icu-messageformat-1` plugin in the `README.md` message format section and added an explicit note in `docs/comparison.md` to surface ICU1 support (files changed: `README.md`, `docs/comparison.md`).

### Testing
- No automated tests were run since this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bccd955ac8326835d004fc3ee5ed2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds links/wording about ICU MessageFormat 1 support via a plugin; no runtime or API behavior changes.
> 
> **Overview**
> Clarifies in the docs that Paraglide can support *ICU MessageFormat 1 syntax* via the `inlang-icu-messageformat-1` plugin.
> 
> Adds a direct plugin pointer in `README.md`’s message-format section and an explicit note in `docs/comparison.md` to surface ICU1 support in the comparison narrative.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14a276a36763c7e74a3033c7b2ffb86f41fbc4b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->