### PR TITLE
Add i18n comparison report and ignore artifacts

### DIFF
--- a/.changeset/shiny-crews-shop.md
+++ b/.changeset/shiny-crews-shop.md
@@ -1,0 +1,7 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix single-locale message generation to avoid emitting an unused `locale` variable in strict TypeScript `checkJs` setups. This removes `TS6133` (`'locale' is declared but its value is never read`) warnings for generated message files when only one locale is configured.
+
+Add a regression type test that asserts single-locale generated messages do not produce this warning.

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage/
 Thumbs.db
 
 tsconfig.tsbuildinfo
+
+artifact/

--- a/docs-api/runtime/type/-internal-.md
+++ b/docs-api/runtime/type/-internal-.md
@@ -881,7 +881,7 @@ the global strategy is returned.
 
 > **getTextDirection**(`locale?`): `"ltr"` \| `"rtl"`
 
-Defined in: [runtime/get-text-direction.js:19](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/get-text-direction.js)
+Defined in: [runtime/get-text-direction.js:31](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/get-text-direction.js)
 
 Get writing direction for a locale.
 

--- a/src/compiler/compile-bundle.ts
+++ b/src/compiler/compile-bundle.ts
@@ -197,6 +197,20 @@ ${englishMatchTableDoc}${jsDocBundleFunctionTypes({
 		return `\n${indent}trackMessageCall("${safeBundleId}", locale)`;
 	};
 
+	const localeResolutionStatement = (indent: string): string => {
+		if (
+			isFullyTranslated &&
+			args.availableLocales.length === 1 &&
+			!args.experimentalMiddlewareLocaleSplitting
+		) {
+			return `${indent}experimentalStaticLocale ?? options.locale ?? getLocale()`;
+		}
+
+		return `${indent}const locale = experimentalStaticLocale ?? options.locale ?? getLocale()${maybeTrackMessageCall(
+			indent
+		)}`;
+	};
+
 	let code = "";
 
 	if (!args.hasMarkup) {
@@ -204,9 +218,7 @@ ${englishMatchTableDoc}${jsDocBundleFunctionTypes({
 ${isSafeBundleId ? "export " : ""}const ${safeBundleId} = /** @type {(${bundleFunctionType}) & ${messageMetadataType}} */ ((inputs${hasInputs ? "" : " = {}"}, options = {}) => {${clientMiddlewareGuard(
 			"\t"
 		)}
-	const locale = experimentalStaticLocale ?? options.locale ?? getLocale()${maybeTrackMessageCall(
-		"\t"
-	)}
+${localeResolutionStatement("\t")}
 	${compileLocaleReturnStatements("string", "\t")}${
 		!isFullyTranslated
 			? `\n	return /** @type {LocalizedString} */ ("${args.bundle.id}")`
@@ -220,9 +232,7 @@ ${isSafeBundleId ? "export " : ""}const ${safeBundleId} = /** @type {(${bundleFu
 		/** @type {${bundleFunctionType}} */ ((inputs${hasInputs ? "" : " = {}"}, options = {}) => {${clientMiddlewareGuard(
 			"\t\t\t"
 		)}
-			const locale = experimentalStaticLocale ?? options.locale ?? getLocale()${maybeTrackMessageCall(
-				"\t\t\t"
-			)}
+${localeResolutionStatement("\t\t\t")}
 			${compileLocaleReturnStatements("string", "\t\t\t")}${
 				!isFullyTranslated
 					? `\n			return /** @type {LocalizedString} */ (${JSON.stringify(args.bundle.id)})`
@@ -233,9 +243,7 @@ ${isSafeBundleId ? "export " : ""}const ${safeBundleId} = /** @type {(${bundleFu
 			parts: /** @type {${partsFunctionType}} */ ((inputs${
 				hasInputs ? "" : " = {}"
 			}, options = {}) => {${clientPartsMiddlewareGuard("\t\t\t\t")}
-				const locale = experimentalStaticLocale ?? options.locale ?? getLocale()${maybeTrackMessageCall(
-					"\t\t\t\t"
-				)}
+${localeResolutionStatement("\t\t\t\t")}
 				${compileLocaleReturnStatements("parts", "\t\t\t\t")}${
 					!isFullyTranslated
 						? `\n				return /** @type {import('../runtime.js').MessagePart[]} */ ([{ type: "text", value: ${JSON.stringify(args.bundle.id)} }])`
@@ -271,7 +279,9 @@ function buildEnglishMatchTableDoc(bundle: BundleNested): string {
 	];
 
 	for (const variant of message.variants) {
-		const rowValues = selectorKeys.map((key) => getMatchCellValue(variant, key));
+		const rowValues = selectorKeys.map((key) =>
+			getMatchCellValue(variant, key)
+		);
 		const serializedOutput = serializePatternPreview(variant.pattern);
 		const outputValue = JSON.stringify(
 			serializedOutput.length > 160
@@ -297,7 +307,9 @@ function selectEnglishMessage(
 	);
 }
 
-function collectSelectorKeys(message: BundleNested["messages"][number]): string[] {
+function collectSelectorKeys(
+	message: BundleNested["messages"][number]
+): string[] {
 	const keys: string[] = [];
 	const seen = new Set<string>();
 

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -1030,6 +1030,66 @@ describe.each([
 			}
 			expect(diagnostics.length).toEqual(0);
 		});
+
+		test("./messages.js types (single locale should not emit TS6133)", async () => {
+			const singleLocaleProject = await loadProjectInMemory({
+				blob: await newProject({
+					settings: { locales: ["en"], baseLocale: "en" },
+				}),
+			});
+
+			await insertBundleNested(
+				singleLocaleProject.db,
+				createBundleNested({
+					id: "single_locale_message",
+					messages: [
+						{
+							locale: "en",
+							variants: [{ pattern: [{ type: "text", value: "Hello" }] }],
+						},
+					],
+				})
+			);
+
+			const singleLocaleOutput = await compileProject({
+				project: singleLocaleProject,
+				compilerOptions,
+			});
+
+			const project = await typescriptProject({
+				useInMemoryFileSystem: true,
+				compilerOptions: superStrictRuleOutAnyErrorTsSettings,
+			});
+
+			for (const [fileName, code] of Object.entries(singleLocaleOutput)) {
+				if (fileName.endsWith(".js") || fileName.endsWith(".ts")) {
+					project.createSourceFile(fileName, code);
+				}
+			}
+
+			project.createSourceFile(
+				"test.ts",
+				`import { single_locale_message } from "./messages.js"; single_locale_message();`
+			);
+
+			const program = project.createProgram();
+			const diagnostics = ts.getPreEmitDiagnostics(program).filter((d) => {
+				return !d.messageText
+					.toString()
+					.includes("Cannot find module 'async_hooks'");
+			});
+
+			const ts6133LocaleDiagnostics = diagnostics.filter((d) => {
+				return (
+					d.code === 6133 &&
+					d.messageText
+						.toString()
+						.includes("'locale' is declared but its value is never read")
+				);
+			});
+
+			expect(ts6133LocaleDiagnostics.length).toEqual(0);
+		});
 	}
 );
 


### PR DESCRIPTION



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only affect generated message code when exactly one locale is configured (and middleware locale splitting is off), plus adds a regression typecheck test.
> 
> **Overview**
> Fixes single-locale codegen so generated `messages.js` no longer declares an unused `locale` variable (preventing TS `checkJs`/`noUnusedLocals` `TS6133` warnings) when the project is fully translated and `experimentalMiddlewareLocaleSplitting` is disabled.
> 
> Adds a regression test that compiles a single-locale project and asserts TypeScript diagnostics do not include the unused-`locale` warning, updates generated API docs line references, and ignores `artifact/` outputs via `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d79aff38eb56a1922622828732092dac3785409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary locale variable generation in single-locale projects that triggered TypeScript warnings in strict mode.

* **Tests**
  * Added regression test to prevent recurrence of unused variable warnings in single-locale configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->