### PR TITLE
Fix SvelteKit example links for resolve lint rule

### DIFF
--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -124,12 +124,13 @@ Then add a locale switcher in `routes/+layout.svelte` to generate all pages duri
 ```diff
 <script>
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
 	import { locales, localizeHref } from '$lib/paraglide/runtime';
 </script>
 
 <nav class="locale-switcher" aria-label="Languages">
 	{#each locales as locale}
-		<a href={localizeHref(page.url.pathname, { locale })} data-sveltekit-reload>
+		<a href={resolve(localizeHref(page.url.pathname, { locale }))} data-sveltekit-reload>
 			{locale}
 		</a>
 	{/each}

--- a/examples/sveltekit/src/routes/+layout.svelte
+++ b/examples/sveltekit/src/routes/+layout.svelte
@@ -1,11 +1,12 @@
 <script>
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { locales, localizeHref } from '$lib/paraglide/runtime';
 </script>
 
 <nav class="locale-switcher" aria-label="Languages">
 	{#each locales as locale}
-		<a href={localizeHref(page.url.pathname, { locale })} data-sveltekit-reload>
+		<a href={resolve(localizeHref(page.url.pathname, { locale }))} data-sveltekit-reload>
 			{locale}
 		</a>
 	{/each}

--- a/examples/sveltekit/src/routes/+page.svelte
+++ b/examples/sveltekit/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { m } from '$lib/paraglide/messages';
 	import { localizeHref, setLocale } from '$lib/paraglide/runtime';
 </script>
@@ -10,5 +11,5 @@
 
 <br />
 <br />
-<a href={localizeHref('/about', { locale: 'en' })}>go to about in en</a>
-<a href={localizeHref('/about', { locale: 'de' })}>go to about in de</a>
+<a href={resolve(localizeHref('/about', { locale: 'en' }))}>go to about in en</a>
+<a href={resolve(localizeHref('/about', { locale: 'de' }))}>go to about in de</a>

--- a/examples/sveltekit/src/routes/about/+page.svelte
+++ b/examples/sveltekit/src/routes/about/+page.svelte
@@ -1,8 +1,9 @@
 <script>
+	import { resolve } from '$app/paths';
 	import { localizeHref } from '$lib/paraglide/runtime';
 	import { m } from '$lib/paraglide/messages';
 </script>
 
 <p>{m.about()}</p>
 
-<a href={localizeHref('/')}>go back to home</a>
+<a href={resolve(localizeHref('/'))}>go back to home</a>


### PR DESCRIPTION
Related https://github.com/opral/paraglide-js/issues/638

## Summary
- wrap SvelteKit example locale/navigation links with `$app/paths.resolve(...)`
- update the SvelteKit README snippet to show the same pattern
- keep `data-sveltekit-reload` behavior unchanged

## Why
The SvelteKit ESLint rule `svelte/no-navigation-without-resolve` flags direct `href={localizeHref(...)}` usage. The reporter repro passes once the links are changed to `href={resolve(localizeHref(...))}`.

## Verification
- reproduced the lint error in `bennajah/svelte-demo`
- confirmed `pnpm lint` passes there after applying the same change
- ran `pnpm --filter @inlang/paraglide-js-example-sveltekit build` in this repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/example change that only affects how example `href`s are constructed; behavior should remain the same aside from ensuring correct base-path resolution and satisfying the SvelteKit lint rule.
> 
> **Overview**
> Updates the SvelteKit example to wrap all localized navigation links with `resolve(...)` from `$app/paths`, including the locale switcher and example page links.
> 
> Mirrors the same pattern in the `examples/sveltekit/README.md` snippet so the documented SSG locale-switcher code matches the lint-compliant implementation, while keeping `data-sveltekit-reload` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b44ffdfa57cbbc83d948acb8ca65a5bbe65c36ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->