### PR TITLE
chore: update @inlang/sdk to 2.9.1

### DIFF
--- a/.changeset/late-lions-bathe.md
+++ b/.changeset/late-lions-bathe.md
@@ -2,4 +2,4 @@
 "@inlang/paraglide-js": patch
 ---
 
-Update `@inlang/sdk` to `2.9.0`.
+Update `@inlang/sdk` to `2.9.1`.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	},
 	"dependencies": {
 		"@inlang/recommend-sherlock": "^0.2.1",
-		"@inlang/sdk": "^2.9.0",
+		"@inlang/sdk": "^2.9.1",
 		"commander": "11.1.0",
 		"consola": "3.4.0",
 		"json5": "2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       '@inlang/sdk':
-        specifier: ^2.9.0
-        version: 2.9.0(babel-plugin-macros@3.1.0)
+        specifier: ^2.9.1
+        version: 2.9.1(babel-plugin-macros@3.1.0)
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1534,8 +1534,8 @@ packages:
     resolution: {integrity: sha512-cvz/C1rF5WBxzHbEoiBoI6Sz6q6M+TdxfWkEGBYTD77opY8i8WN01prUWXEM87GPF4SZcyIySez9U0Ccm12oFQ==}
     engines: {node: '>=18.0.0'}
 
-  '@inlang/sdk@2.9.0':
-    resolution: {integrity: sha512-CfaKtwnPZpVcq3/+/IpMO1NrbyrODNzfwGvMuxoUQjojnC7+9Omtuz1Ol3Hy+tfS6i9zmSvu3c5Ru1/Zzq8QhA==}
+  '@inlang/sdk@2.9.1':
+    resolution: {integrity: sha512-y0C3xaKo6pSGDr3p5OdreRVT3THJpgKVe1lLvG3BE4v9lskp3UfI9cPCbN8X2dpfLt/4ljtehMb5SykpMfJrMg==}
     engines: {node: '>=20.0.0'}
 
   '@inquirer/external-editor@1.0.3':
@@ -1611,8 +1611,8 @@ packages:
     resolution: {integrity: sha512-pRbW+joG12L0ULfMiWYosIW0plmW4AsUdiPCp+Z8rAsElJ+wJ6in58zhD3UwUcd4BNcpldEGjg6PdA7e0RgsDQ==}
     engines: {node: '>=18'}
 
-  '@lix-js/sdk@0.4.8':
-    resolution: {integrity: sha512-H0nbC7ruhom1WQHmaXje6hyp8LYKqHw4VsJIm+i3QQMmz70Qr4MEIiy2Epma2AFSVD2rdIfIY4mQ+8WdCtjR3Q==}
+  '@lix-js/sdk@0.4.9':
+    resolution: {integrity: sha512-30mDkXpx704359oRrJI42bjfCspCiaMItngVBbPkiTGypS7xX4jYbHWQkXI8XuJ7VDB69D0MsVU6xfrBAIrM4A==}
     engines: {node: '>=18'}
 
   '@lix-js/server-protocol-schema@0.1.1':
@@ -7218,9 +7218,9 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@inlang/sdk@2.9.0(babel-plugin-macros@3.1.0)':
+  '@inlang/sdk@2.9.1(babel-plugin-macros@3.1.0)':
     dependencies:
-      '@lix-js/sdk': 0.4.8(babel-plugin-macros@3.1.0)
+      '@lix-js/sdk': 0.4.9(babel-plugin-macros@3.1.0)
       '@sinclair/typebox': 0.31.28
       kysely: 0.28.14
       sqlite-wasm-kysely: 0.3.0(kysely@0.28.14)
@@ -7313,7 +7313,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@lix-js/sdk@0.4.8(babel-plugin-macros@3.1.0)':
+  '@lix-js/sdk@0.4.9(babel-plugin-macros@3.1.0)':
     dependencies:
       '@lix-js/server-protocol-schema': 0.1.1
       dedent: 1.5.1(babel-plugin-macros@3.1.0)


### PR DESCRIPTION
## Summary
- update `@inlang/sdk` from `^2.9.0` to `^2.9.1`
- refresh `pnpm-lock.yaml` for the new release and transitive `@lix-js/sdk` update
- keep the patch changeset aligned with the released SDK version

## Validation
- `pnpm run ci`

## Notes
- confirmed the latest published `@inlang/sdk` version is `2.9.1`
- `@inlang/sdk@2.9.1` still declares `node >=20`, which matches this repo's documented prerequisite and CI baseline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but `@inlang/sdk@2.9.1` raises its Node engine requirement to `>=20`, which could break consumers/environments still on Node 18.
> 
> **Overview**
> Updates `@inlang/sdk` from `^2.8.0` to `^2.9.1` and refreshes `pnpm-lock.yaml` to the newly resolved dependency graph (including updated transitive deps like `@lix-js/sdk` and `kysely`).
> 
> Adds a patch changeset for `@inlang/paraglide-js` documenting the SDK bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9ce5b334c59fd722b951787fef77366fc23506c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->