### PR TITLE
feat(cli): add compile flags for emitGitIgnore, emitPrettierIgnore, a…

### DIFF
--- a/src/cli/commands/compile/command.ts
+++ b/src/cli/commands/compile/command.ts
@@ -72,6 +72,14 @@ export const compileCommand = new Command()
 		"--no-emit-readme",
 		"Do not emit README.md in the output directory"
 	)
+	.option(
+		"--is-server <expression>",
+		[
+			"JavaScript expression for runtime `isServer` (enables server/client tree-shaking).",
+			'Quote if the expression contains spaces, e.g. --is-server \'typeof window === "undefined"\'.',
+			"Vite SSR example: --is-server 'import.meta.env.SSR'",
+		].join(" ")
+	)
 	.option("--watch", "Watch project files and recompile on change", false)
 	.action(
 		async (options: {
@@ -83,6 +91,7 @@ export const compileCommand = new Command()
 			emitGitIgnore?: CompilerOptions["emitGitIgnore"];
 			emitPrettierIgnore?: CompilerOptions["emitPrettierIgnore"];
 			emitReadme?: CompilerOptions["emitReadme"];
+			isServer?: CompilerOptions["isServer"];
 			watch?: boolean;
 		}) => {
 			const logger = new Logger({ silent: options.silent, prefix: true });
@@ -101,6 +110,7 @@ export const compileCommand = new Command()
 					options.emitPrettierIgnore ??
 					defaultCompilerOptions.emitPrettierIgnore,
 				emitReadme: options.emitReadme ?? defaultCompilerOptions.emitReadme,
+				isServer: options.isServer ?? defaultCompilerOptions.isServer,
 			};
 
 			if (!options.watch) {

--- a/src/cli/commands/compile/command.ts
+++ b/src/cli/commands/compile/command.ts
@@ -41,6 +41,37 @@ export const compileCommand = new Command()
 		"Emit .d.ts files for the generated output (requires the typescript package)",
 		defaultCompilerOptions.emitTsDeclarations
 	)
+	.option(
+		"--no-emit-ts-declarations",
+		"Do not emit .d.ts files for the generated output"
+	)
+	.option(
+		"--emit-git-ignore",
+		"Emit a .gitignore in the output directory",
+		defaultCompilerOptions.emitGitIgnore
+	)
+	.option(
+		"--no-emit-git-ignore",
+		"Do not emit a .gitignore in the output directory"
+	)
+	.option(
+		"--emit-prettier-ignore",
+		"Emit a .prettierignore in the output directory",
+		defaultCompilerOptions.emitPrettierIgnore
+	)
+	.option(
+		"--no-emit-prettier-ignore",
+		"Do not emit a .prettierignore in the output directory"
+	)
+	.option(
+		"--emit-readme",
+		"Emit a README.md in the output directory (helps LLMs understand the generated code)",
+		defaultCompilerOptions.emitReadme
+	)
+	.option(
+		"--no-emit-readme",
+		"Do not emit README.md in the output directory"
+	)
 	.option("--watch", "Watch project files and recompile on change", false)
 	.action(
 		async (options: {
@@ -49,6 +80,9 @@ export const compileCommand = new Command()
 			outdir: string;
 			strategy?: CompilerOptions["strategy"];
 			emitTsDeclarations?: CompilerOptions["emitTsDeclarations"];
+			emitGitIgnore?: CompilerOptions["emitGitIgnore"];
+			emitPrettierIgnore?: CompilerOptions["emitPrettierIgnore"];
+			emitReadme?: CompilerOptions["emitReadme"];
 			watch?: boolean;
 		}) => {
 			const logger = new Logger({ silent: options.silent, prefix: true });
@@ -61,6 +95,12 @@ export const compileCommand = new Command()
 				emitTsDeclarations:
 					options.emitTsDeclarations ??
 					defaultCompilerOptions.emitTsDeclarations,
+				emitGitIgnore:
+					options.emitGitIgnore ?? defaultCompilerOptions.emitGitIgnore,
+				emitPrettierIgnore:
+					options.emitPrettierIgnore ??
+					defaultCompilerOptions.emitPrettierIgnore,
+				emitReadme: options.emitReadme ?? defaultCompilerOptions.emitReadme,
 			};
 
 			if (!options.watch) {


### PR DESCRIPTION
## Summary

Adds CLI flags on `paraglide-js compile` so more **`CompilerOptions`** fields that bundler plugins already expose can be set from the command line—especially **emit** toggles and **`isServer`**.

## Changes

### Emit output (parity with plugins)

- **`emitGitIgnore`**: `--emit-git-ignore` / `--no-emit-git-ignore` (default: on)
- **`emitPrettierIgnore`**: `--emit-prettier-ignore` / `--no-emit-prettier-ignore` (default: on)
- **`emitReadme`**: `--emit-readme` / `--no-emit-readme` (default: on)
- **`emitTsDeclarations`**: `--no-emit-ts-declarations` alongside existing `--emit-ts-declarations` (default: off)

### Runtime / tree-shaking

- **`isServer`**: `--is-server <expression>` — JavaScript expression emitted as `isServer` in generated `runtime.js` (default: `typeof window === 'undefined'` when omitted). Quote the value if it contains spaces, e.g. `--is-server 'typeof window === "undefined"'` or `--is-server 'import.meta.env.SSR'`.

Parsed values are passed through to `compile()` so normal runs and `--watch` stay consistent.

## Motivation

Bundler integrations already expose these options; the CLI did not, which made it harder to:

- Opt out of generated `.gitignore`, `.prettierignore`, or `README.md` in CI or scripts without the programmatic API.
- Control `.d.ts` emission and the `isServer` expression without calling `compile()` from code.

## Testing

- `pnpm exec tsc --noEmit`
- Manual: `paraglide-js compile --help` lists the new options

Fixes https://github.com/opral/paraglide-js/issues/189#issuecomment-3519428715