### PR TITLE
fix: harden clean outdir race follow-ups

### DIFF
--- a/.changeset/fix-cleanoutdir-race.md
+++ b/.changeset/fix-cleanoutdir-race.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix race condition where `paraglideVitePlugin` (and the rollup/rolldown/rspack/esbuild plugins) wiped the output directory on every fresh process, racing concurrent reads from SSR/prerender modules and sibling Vite instances. The plugin now seeds `previousCompilation` from existing on-disk hashes on the first compile, so warm restarts are a no-op (zero writes when inputs haven't changed) and the recursive wipe is gone. The webpack plugin's wipe behavior is unchanged but now also deletes orphaned files on its first compile. Closes #659.

--- a/src/bundler-plugins/unplugin.test.ts
+++ b/src/bundler-plugins/unplugin.test.ts
@@ -106,9 +106,8 @@ test("vite plugin throws on compilation errors at build time", async () => {
 // concurrent reads (SSR/prerender modules, sibling Vite processes, the
 // config-watcher reload) and producing ENOENT/MISSING_EXPORT/ERR_LOAD_URL.
 test("vite plugin does not wipe outdir during first buildStart (#659)", async () => {
-	const { paraglideVitePlugin: vitePlugin } = await import(
-		"../bundler-plugins/vite.js"
-	);
+	const { paraglideVitePlugin: vitePlugin } =
+		await import("../bundler-plugins/vite.js");
 
 	const project = await loadProjectInMemory({
 		blob: await newProject({
@@ -137,6 +136,7 @@ test("vite plugin does not wipe outdir during first buildStart (#659)", async ()
 	const plugin = vitePlugin({
 		project: "/project.inlang",
 		outdir: "/test-output",
+		cleanOutdir: true,
 		fs: fs,
 	}) as any;
 
@@ -173,9 +173,8 @@ test("vite plugin warm-restart writes nothing when inputs unchanged (#659)", asy
 
 	// First process: compile and persist files to outdir.
 	{
-		const { paraglideVitePlugin: vitePlugin } = await import(
-			"../bundler-plugins/vite.js"
-		);
+		const { paraglideVitePlugin: vitePlugin } =
+			await import("../bundler-plugins/vite.js");
 		const plugin = vitePlugin({
 			project: "/project.inlang",
 			outdir: "/test-output",
@@ -188,9 +187,8 @@ test("vite plugin warm-restart writes nothing when inputs unchanged (#659)", asy
 	// the module-scoped `previousCompilation` is undefined again. The plugin
 	// should seed from on-disk hashes and write zero files (no race window).
 	vi.resetModules();
-	const { paraglideVitePlugin: vitePluginFresh } = await import(
-		"../bundler-plugins/vite.js"
-	);
+	const { paraglideVitePlugin: vitePluginFresh } =
+		await import("../bundler-plugins/vite.js");
 	const plugin2 = vitePluginFresh({
 		project: "/project.inlang",
 		outdir: "/test-output",

--- a/src/bundler-plugins/unplugin.test.ts
+++ b/src/bundler-plugins/unplugin.test.ts
@@ -13,6 +13,10 @@ let originalNodeEnv: string | undefined;
 beforeEach(() => {
 	originalNodeEnv = process.env.NODE_ENV;
 
+	// Reset module state between tests so the module-scoped
+	// `previousCompilation` doesn't leak across tests.
+	vi.resetModules();
+
 	// Mock logging methods to suppress error messages in tests
 	consola.mockTypes(() => vi.fn());
 });
@@ -95,4 +99,106 @@ test("vite plugin throws on compilation errors at build time", async () => {
 
 	// In production mode - should throw the error
 	await expect(plugin.buildStart?.call(mockContext)).rejects.toThrow();
+});
+
+// Regression test for https://github.com/opral/inlang-paraglide-js/issues/659:
+// the bundler plugins used to wipe `outdir` on every fresh process, racing
+// concurrent reads (SSR/prerender modules, sibling Vite processes, the
+// config-watcher reload) and producing ENOENT/MISSING_EXPORT/ERR_LOAD_URL.
+test("vite plugin does not wipe outdir during first buildStart (#659)", async () => {
+	const { paraglideVitePlugin: vitePlugin } = await import(
+		"../bundler-plugins/vite.js"
+	);
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de", "fr"],
+			},
+		}),
+	});
+
+	const fs = memfs().fs as unknown as typeof import("node:fs");
+
+	await saveProjectToDirectory({
+		project,
+		path: "/project.inlang",
+		fs: fs.promises,
+	});
+
+	// Pre-seed outdir with a sentinel file mimicking a prior compilation
+	// still on disk from an earlier process.
+	await fs.promises.mkdir("/test-output", { recursive: true });
+	await fs.promises.writeFile("/test-output/__sentinel__.txt", "kept");
+
+	const rmSpy = vi.spyOn(fs.promises, "rm");
+
+	const plugin = vitePlugin({
+		project: "/project.inlang",
+		outdir: "/test-output",
+		fs: fs,
+	}) as any;
+
+	const mockContext = { addWatchFile: () => {} };
+	await plugin.buildStart?.call(mockContext);
+
+	// The plugin must not recursively remove the outdir during the first
+	// compile, even though previousCompilation is undefined. Concurrent
+	// readers may be holding file handles into outdir.
+	for (const call of rmSpy.mock.calls) {
+		expect(call[0]).not.toBe("/test-output");
+	}
+});
+
+test("vite plugin warm-restart writes nothing when inputs unchanged (#659)", async () => {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de", "fr"],
+			},
+		}),
+	});
+
+	const fs = memfs().fs as unknown as typeof import("node:fs");
+
+	await saveProjectToDirectory({
+		project,
+		path: "/project.inlang",
+		fs: fs.promises,
+	});
+
+	const mockContext = { addWatchFile: () => {} };
+
+	// First process: compile and persist files to outdir.
+	{
+		const { paraglideVitePlugin: vitePlugin } = await import(
+			"../bundler-plugins/vite.js"
+		);
+		const plugin = vitePlugin({
+			project: "/project.inlang",
+			outdir: "/test-output",
+			fs: fs,
+		}) as any;
+		await plugin.buildStart?.call(mockContext);
+	}
+
+	// Second process: simulate a fresh node process by resetting modules so
+	// the module-scoped `previousCompilation` is undefined again. The plugin
+	// should seed from on-disk hashes and write zero files (no race window).
+	vi.resetModules();
+	const { paraglideVitePlugin: vitePluginFresh } = await import(
+		"../bundler-plugins/vite.js"
+	);
+	const plugin2 = vitePluginFresh({
+		project: "/project.inlang",
+		outdir: "/test-output",
+		fs: fs,
+	}) as any;
+
+	const writeFileSpy = vi.spyOn(fs.promises, "writeFile");
+	await plugin2.buildStart?.call(mockContext);
+
+	expect(writeFileSpy).not.toHaveBeenCalled();
 });

--- a/src/bundler-plugins/unplugin.ts
+++ b/src/bundler-plugins/unplugin.ts
@@ -23,6 +23,14 @@ let isServer: string | undefined;
 let previousCompilation: CompilationResult | undefined;
 const { fs: trackedFs, readFiles, clearReadFiles } = createTrackedFs();
 
+function withoutCleanOutdir(
+	args: CompilerOptions
+): Omit<CompilerOptions, "cleanOutdir"> {
+	const { cleanOutdir, ...compileArgs } = args;
+	void cleanOutdir;
+	return compileArgs;
+}
+
 /**
  * Seed a synthetic `previousCompilation` from files already on disk in
  * `outdir`. This lets the first compile in a fresh process diff against
@@ -38,10 +46,7 @@ async function seedPreviousCompilation(
 ): Promise<CompilationResult | undefined> {
 	const absoluteOutdir = path.resolve(process.cwd(), outdir);
 	const resolvedFs = fs ?? (await import("node:fs"));
-	const outputHashes = await hashDirectory(
-		absoluteOutdir,
-		resolvedFs.promises
-	);
+	const outputHashes = await hashDirectory(absoluteOutdir, resolvedFs.promises);
 	if (!outputHashes) return undefined;
 	return { outputHashes };
 }
@@ -67,9 +72,9 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 				fs: trackedFs,
 				previousCompilation: seededPrevious,
 				outputStructure,
-				cleanOutdir: false,
 				isServer,
-				...args,
+				...withoutCleanOutdir(args),
+				cleanOutdir: false,
 			});
 			logger.success(`Compilation complete (${outputStructure})`);
 		} catch (error) {
@@ -122,9 +127,9 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 				fs: trackedFs,
 				previousCompilation,
 				outputStructure,
-				cleanOutdir: false,
 				isServer,
-				...args,
+				...withoutCleanOutdir(args),
+				cleanOutdir: false,
 			});
 
 			logger.success(`Re-compilation complete (${outputStructure})`);
@@ -184,8 +189,8 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 					fs: trackedFs,
 					previousCompilation: seededPrevious,
 					outputStructure,
+					...withoutCleanOutdir(args),
 					cleanOutdir: false,
-					...args,
 				});
 				logger.success(`Compilation complete (${outputStructure})`);
 			} catch (error) {

--- a/src/bundler-plugins/unplugin.ts
+++ b/src/bundler-plugins/unplugin.ts
@@ -1,6 +1,6 @@
 import type { UnpluginFactory } from "unplugin";
 import { compile, type CompilationResult } from "../compiler/compile.js";
-import { relative } from "node:path";
+import path, { relative } from "node:path";
 import { Logger } from "../services/logger/index.js";
 import type { CompilerOptions } from "../compiler/compiler-options.js";
 import {
@@ -9,6 +9,7 @@ import {
 	isPathWithinDirectories,
 } from "../services/file-watching/tracked-fs.js";
 import { nodeNormalizePath } from "../utilities/node-normalize-path.js";
+import { hashDirectory } from "../services/file-handling/write-output.js";
 
 const PLUGIN_NAME = "unplugin-paraglide-js";
 
@@ -22,6 +23,29 @@ let isServer: string | undefined;
 let previousCompilation: CompilationResult | undefined;
 const { fs: trackedFs, readFiles, clearReadFiles } = createTrackedFs();
 
+/**
+ * Seed a synthetic `previousCompilation` from files already on disk in
+ * `outdir`. This lets the first compile in a fresh process diff against
+ * the prior build's output instead of treating it as empty — so warm
+ * restarts produce zero writes and we never wipe `outdir` out from under
+ * concurrent readers (SSR/prerender, sibling Vite processes).
+ *
+ * See https://github.com/opral/inlang-paraglide-js/issues/659.
+ */
+async function seedPreviousCompilation(
+	outdir: string,
+	fs: typeof import("node:fs") | undefined
+): Promise<CompilationResult | undefined> {
+	const absoluteOutdir = path.resolve(process.cwd(), outdir);
+	const resolvedFs = fs ?? (await import("node:fs"));
+	const outputHashes = await hashDirectory(
+		absoluteOutdir,
+		resolvedFs.promises
+	);
+	if (!outputHashes) return undefined;
+	return { outputHashes };
+}
+
 export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 	name: PLUGIN_NAME,
 	enforce: "pre",
@@ -33,14 +57,17 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 			args.outputStructure ??
 			(isProduction ? "message-modules" : "locale-modules");
 		try {
+			// On a fresh process, seed previousCompilation from on-disk hashes
+			// so the first compile is a no-op when inputs are unchanged. Avoids
+			// racing concurrent readers that wiping outdir would interrupt.
+			const seededPrevious =
+				previousCompilation ??
+				(await seedPreviousCompilation(args.outdir, args.fs));
 			previousCompilation = await compile({
 				fs: trackedFs,
-				previousCompilation,
+				previousCompilation: seededPrevious,
 				outputStructure,
-				// webpack invokes the `buildStart` api in watch mode,
-				// to avoid cleaning the output directory in watch mode,
-				// we only clean the output directory if there was no previous compilation
-				cleanOutdir: previousCompilation === undefined,
+				cleanOutdir: false,
 				isServer,
 				...args,
 			});
@@ -150,13 +177,13 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 				args.outputStructure ??
 				(isProduction ? "message-modules" : "locale-modules");
 			try {
+				const seededPrevious =
+					previousCompilation ??
+					(await seedPreviousCompilation(args.outdir, args.fs));
 				previousCompilation = await compile({
 					fs: trackedFs,
-					previousCompilation,
+					previousCompilation: seededPrevious,
 					outputStructure,
-					// clean dir needs to be false. otherwise webpack get's into a race condition
-					// of deleting the output directory and writing files at the same time for
-					// multi environment builds
 					cleanOutdir: false,
 					...args,
 				});

--- a/src/services/file-handling/write-output.test.ts
+++ b/src/services/file-handling/write-output.test.ts
@@ -217,6 +217,34 @@ test("should delete files that have been removed from the output", async () => {
 	).rejects.toBeDefined();
 });
 
+test("hashDirectory matches the hashes writeOutput returns", async () => {
+	const { writeOutput, hashDirectory } = await import("./write-output.js");
+	const fs = mockFs({});
+
+	const output = {
+		"a.txt": "alpha",
+		"nested/b.txt": "beta",
+		"nested/deep/c.txt": "gamma",
+	};
+
+	const writtenHashes = await writeOutput({
+		directory: "/output",
+		output,
+		fs,
+	});
+
+	const seededHashes = await hashDirectory("/output", fs);
+
+	expect(seededHashes).toEqual(writtenHashes);
+});
+
+test("hashDirectory returns undefined when directory does not exist", async () => {
+	const { hashDirectory } = await import("./write-output.js");
+	const fs = mockFs({});
+
+	expect(await hashDirectory("/nope", fs)).toBeUndefined();
+});
+
 const mockFs = (files: memfs.DirectoryJSON) => {
 	const _memfs = memfs.createFsFromVolume(memfs.Volume.fromJSON(files));
 	return _memfs.promises as unknown as typeof fs;

--- a/src/services/file-handling/write-output.test.ts
+++ b/src/services/file-handling/write-output.test.ts
@@ -245,6 +245,45 @@ test("hashDirectory returns undefined when directory does not exist", async () =
 	expect(await hashDirectory("/nope", fs)).toBeUndefined();
 });
 
+test("hashDirectory skips files that disappear while walking", async () => {
+	const { hashDirectory } = await import("./write-output.js");
+	const fs = mockFs({
+		"/output/a.txt": "alpha",
+		"/output/b.txt": "beta",
+	});
+	const readFile = fs.readFile.bind(fs);
+	vi.spyOn(fs, "readFile").mockImplementation((async (...args) => {
+		if (args[0] === "/output/b.txt") {
+			throw new Error("file disappeared");
+		}
+		return readFile(args[0], args[1]);
+	}) as typeof fs.readFile);
+
+	const seededHashes = await hashDirectory("/output", fs);
+
+	expect(seededHashes).toEqual({
+		"a.txt": expect.any(String),
+	});
+});
+
+test("hashDirectory skips directories that disappear while walking", async () => {
+	const { hashDirectory } = await import("./write-output.js");
+	const fs = mockFs({
+		"/output/nested/b.txt": "beta",
+	});
+	const readdir = fs.readdir.bind(fs);
+	vi.spyOn(fs, "readdir").mockImplementation((async (...args) => {
+		if (args[0] === "/output/nested") {
+			throw new Error("directory disappeared");
+		}
+		return readdir(args[0], args[1] as never);
+	}) as typeof fs.readdir);
+
+	const seededHashes = await hashDirectory("/output", fs);
+
+	expect(seededHashes).toEqual({});
+});
+
 const mockFs = (files: memfs.DirectoryJSON) => {
 	const _memfs = memfs.createFsFromVolume(memfs.Volume.fromJSON(files));
 	return _memfs.promises as unknown as typeof fs;

--- a/src/services/file-handling/write-output.ts
+++ b/src/services/file-handling/write-output.ts
@@ -176,7 +176,12 @@ export async function hashDirectory(
 	const hashes: Record<string, string> = {};
 
 	async function walk(currentDir: string, relativePrefix: string) {
-		const entries = await fs.readdir(currentDir, { withFileTypes: true });
+		let entries;
+		try {
+			entries = await fs.readdir(currentDir, { withFileTypes: true });
+		} catch {
+			return;
+		}
 		for (const entry of entries) {
 			const entryAbsolutePath = path.resolve(currentDir, entry.name);
 			const relativePath = relativePrefix
@@ -185,10 +190,15 @@ export async function hashDirectory(
 			if (entry.isDirectory()) {
 				await walk(entryAbsolutePath, relativePath);
 			} else if (entry.isFile()) {
-				const fileContent = await fs.readFile(entryAbsolutePath, "utf-8");
-				const combinedContent =
-					fileContent + path.resolve(directory, relativePath);
-				hashes[relativePath] = await hashString(combinedContent);
+				try {
+					const fileContent = await fs.readFile(entryAbsolutePath, "utf-8");
+					const combinedContent =
+						fileContent + path.resolve(directory, relativePath);
+					hashes[relativePath] = await hashString(combinedContent);
+				} catch {
+					// Another compiler process may be rewriting this file. A partial
+					// seed is safe; the following compile will repair missing outputs.
+				}
 			}
 		}
 	}

--- a/src/services/file-handling/write-output.ts
+++ b/src/services/file-handling/write-output.ts
@@ -149,3 +149,50 @@ async function hashOutput(
 	}
 	return hashes;
 }
+
+/**
+ * Walk an existing output directory and produce the same hash map that
+ * {@link writeOutput} would have returned on a previous compile.
+ *
+ * Used by the bundler plugins to seed `previousCompilation` on a fresh
+ * process so the first compile's diff against unchanged inputs is empty
+ * and `writeOutput` short-circuits — letting us avoid wiping the directory
+ * out from under concurrent SSR/prerender readers (#659).
+ *
+ * Returns `undefined` if the directory does not exist. Keys are
+ * forward-slash relative paths to match {@link hashOutput}.
+ */
+export async function hashDirectory(
+	directory: string,
+	fs: typeof nodeFs
+): Promise<Record<string, string> | undefined> {
+	try {
+		const stat = await fs.stat(directory);
+		if (!stat.isDirectory()) return undefined;
+	} catch {
+		return undefined;
+	}
+
+	const hashes: Record<string, string> = {};
+
+	async function walk(currentDir: string, relativePrefix: string) {
+		const entries = await fs.readdir(currentDir, { withFileTypes: true });
+		for (const entry of entries) {
+			const entryAbsolutePath = path.resolve(currentDir, entry.name);
+			const relativePath = relativePrefix
+				? `${relativePrefix}/${entry.name}`
+				: entry.name;
+			if (entry.isDirectory()) {
+				await walk(entryAbsolutePath, relativePath);
+			} else if (entry.isFile()) {
+				const fileContent = await fs.readFile(entryAbsolutePath, "utf-8");
+				const combinedContent =
+					fileContent + path.resolve(directory, relativePath);
+				hashes[relativePath] = await hashString(combinedContent);
+			}
+		}
+	}
+
+	await walk(directory, "");
+	return hashes;
+}


### PR DESCRIPTION
## Summary
- carries forward #669 by @nachogarcia, preserving the original contributor commit in this branch
- forces bundler plugins to ignore cleanOutdir so user config cannot re-enable the unsafe outdir wipe
- makes hashDirectory tolerate files or directories disappearing during the seed walk

## Validation
- pnpm exec vitest run src/bundler-plugins/unplugin.test.ts src/services/file-handling/write-output.test.ts
- pnpm exec tsc --noEmit

This is intended as a companion/replacement branch so #669's source branch can stay clean while Nacho's original commit remains in the history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit abff6682bb47c2bf49cd5aec953470b26c6d8e5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->