### PR TITLE
feat: add relativetime declaration formatter

### DIFF
--- a/.changeset/sharp-timers-compare.md
+++ b/.changeset/sharp-timers-compare.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Add a `relativetime` declaration formatter backed by `Intl.RelativeTimeFormat`.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Paraglide supports locale-aware formatting via declaration formatters:
 - `plural` (`Intl.PluralRules`) for plural and ordinal categories
 - `number` (`Intl.NumberFormat`) for numbers, currency, compact notation, and more
 - `datetime` (`Intl.DateTimeFormat`) for dates/times with locale-aware output
+- `relativetime` (`Intl.RelativeTimeFormat`) for values like "yesterday", "in 2 days", or "3 hr. ago"
 
 Gender and custom selects are supported via the variants system.
 
@@ -205,7 +206,7 @@ Paraglide is built on the [open inlang format](https://github.com/opral/inlang-s
 - [Getting Started](https://inlang.com/m/gerre34r/library-inlang-paraglideJs)
 - [Framework Guides](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/react-router) (React Router, SvelteKit, Astro, etc.)
 - [Message Syntax & Pluralization](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/variants)
-- [Formatting (Number/Date)](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/formatting)
+- [Formatting (Number/Date/Relative Time)](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/formatting)
 - [Routing & SSR](https://inlang.com/m/gerre34r/library-inlang-paraglideJs/server-side-rendering)
 - [API Reference](https://inlang.com/m/gerre34r/library-inlang-paraglideJs)
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -1,6 +1,6 @@
 ---
 title: Formatting
-description: Locale-aware number and date formatting in Paraglide JS using message declarations.
+description: Locale-aware number, date, and relative-time formatting in Paraglide JS using message declarations.
 ---
 
 # Formatting
@@ -12,9 +12,10 @@ Built-in formatter names:
 - `plural` (uses `Intl.PluralRules`)
 - `number` (uses `Intl.NumberFormat`)
 - `datetime` (uses `Intl.DateTimeFormat`)
+- `relativetime` (uses `Intl.RelativeTimeFormat`)
 
 > [!NOTE]
-> The formatter names are exactly `plural`, `number`, and `datetime`.
+> The formatter names are exactly `plural`, `number`, `datetime`, and `relativetime`.
 
 ## Number formatting
 
@@ -96,6 +97,125 @@ Use `datetime` for date/time values:
 > [!TIP]
 > Use an explicit `timeZone` if output must be stable across environments.
 
+## Relative time formatting
+
+Use `relativetime` for relative durations such as past updates, upcoming deadlines, and "today"/"tomorrow" labels:
+
+```json
+{
+  "last_seen": [{
+    "declarations": [
+      "input duration",
+      "local formattedDuration = duration: relativetime unit=day numeric=auto"
+    ],
+    "match": {
+      "duration=*": "Last seen {formattedDuration}."
+    }
+  }],
+  "delivery_window": [{
+    "declarations": [
+      "input duration",
+      "local formattedDuration = duration: relativetime unit=day"
+    ],
+    "match": {
+      "duration=*": "Arrives {formattedDuration}."
+    }
+  }]
+}
+```
+
+With an English locale, `last_seen({ duration: -1 })` can render "Last seen yesterday.", and `delivery_window({ duration: 2 })` can render "Arrives in 2 days." Negative values are in the past; positive values are in the future.
+
+`unit` is required by Paraglide. It is not an `Intl.RelativeTimeFormatOptions` property because `Intl.RelativeTimeFormat` accepts the unit as a separate argument. Use a literal unit or a dynamic input with `$inputName`:
+
+```json
+{
+  "relative_update": [{
+    "declarations": [
+      "input duration",
+      "input unit",
+      "local formattedDuration = duration: relativetime unit=$unit style=short"
+    ],
+    "match": {
+      "duration=*,unit=*": "Updated {formattedDuration}."
+    }
+  }]
+}
+```
+
+`relative_update({ duration: -3, unit: "hour" })` can render "Updated 3 hr. ago." Invalid dynamic units fail at runtime with the platform `Intl.RelativeTimeFormat` behavior.
+
+Supported units are `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, and `second`. Plural forms such as `days` are accepted by `Intl.RelativeTimeFormat`, but singular forms are recommended for consistency.
+
+`relativetime` forwards supported `Intl.RelativeTimeFormatOptions` such as `localeMatcher`, `numeric`, and `style`:
+
+```json
+{
+  "relative_calendar_day": [{
+    "declarations": [
+      "input duration",
+      "local formattedDuration = duration: relativetime unit=day numeric=auto"
+    ],
+    "match": {
+      "duration=*": "{formattedDuration}"
+    }
+  }],
+  "relative_short_update": [{
+    "declarations": [
+      "input duration",
+      "local formattedDuration = duration: relativetime unit=hour style=short"
+    ],
+    "match": {
+      "duration=*": "Updated {formattedDuration}."
+    }
+  }]
+}
+```
+
+With `numeric=auto`, `-1 day` can become "yesterday", `0 day` can become "today", and `1 day` can become "tomorrow".
+
+Locale overrides work the same as other message calls:
+
+```ts
+import { m } from "./paraglide/messages.js";
+
+m.last_seen({ duration: -1 }, { locale: "de" });
+```
+
+Paraglide formats the `(value, unit)` pair you pass. Automatic threshold selection is caller logic, so compute both values before calling the message:
+
+```ts
+import { m } from "./paraglide/messages.js";
+
+function toRelativeDuration(minutes: number) {
+  const absoluteMinutes = Math.abs(minutes);
+
+  if (absoluteMinutes >= 60 * 24) {
+    return {
+      duration: Math.round(minutes / (60 * 24)),
+      unit: "day",
+    };
+  }
+
+  if (absoluteMinutes >= 60) {
+    return {
+      duration: Math.round(minutes / 60),
+      unit: "hour",
+    };
+  }
+
+  return {
+    duration: minutes,
+    unit: "minute",
+  };
+}
+
+const relative = toRelativeDuration(-125);
+m.relative_update(relative);
+```
+
+Paraglide uses the platform `Intl.RelativeTimeFormat`. Older runtimes need a polyfill.
+
 ## Locale changes and reactivity
 
 Formatting runs when message functions are called. If locale changes, formatted values update the next time the message is evaluated.
@@ -117,12 +237,16 @@ See [Basics](./basics#getting-and-setting-the-locale) for details.
 
 ## Common mistakes
 
-- Using `numberFormat` or `dateFormat`:
-  use `number` and `datetime`.
+- Using `numberFormat`, `dateFormat`, or `relativeTimeFormat`:
+  use `number`, `datetime`, or `relativetime`.
 - Passing already formatted strings:
   pass raw values (`number` / `Date` / parseable date string) and let Paraglide format per locale.
 - Expecting timezone-independent output without a timezone:
   set `timeZone=UTC` (or your target zone) in `datetime` options.
+- Omitting `unit` for `relativetime`:
+  provide a literal unit such as `unit=day` or a dynamic unit such as `unit=$unit`.
+- Expecting `relativetime` to choose units automatically:
+  compute the duration and unit in your app before calling the message.
 
 ## See also
 

--- a/examples/formatting/README.md
+++ b/examples/formatting/README.md
@@ -1,6 +1,6 @@
 # Formatting Example
 
-This example demonstrates number and datetime formatting in message declarations using `local ...: number` and `local ...: datetime`.
+This example demonstrates number, datetime, and relative-time formatting in message declarations using `local ...: number`, `local ...: datetime`, and `local ...: relativetime`.
 The assertions are implemented with Node's built-in `node:test` module in `src/main.ts`.
 
 ## Run

--- a/examples/formatting/messages/de.json
+++ b/examples/formatting/messages/de.json
@@ -31,5 +31,28 @@
 				"date=*": "Kaufdatum: {formattedDate}."
 			}
 		}
+	],
+	"last_seen": [
+		{
+			"declarations": [
+				"input duration",
+				"local formattedDuration = duration: relativetime unit=day numeric=auto"
+			],
+			"match": {
+				"duration=*": "Zuletzt gesehen: {formattedDuration}."
+			}
+		}
+	],
+	"relative_update": [
+		{
+			"declarations": [
+				"input duration",
+				"input unit",
+				"local formattedDuration = duration: relativetime unit=$unit style=short"
+			],
+			"match": {
+				"duration=*,unit=*": "Aktualisiert {formattedDuration}."
+			}
+		}
 	]
 }

--- a/examples/formatting/messages/en.json
+++ b/examples/formatting/messages/en.json
@@ -31,5 +31,28 @@
 				"date=*": "Purchase date: {formattedDate}."
 			}
 		}
+	],
+	"last_seen": [
+		{
+			"declarations": [
+				"input duration",
+				"local formattedDuration = duration: relativetime unit=day numeric=auto"
+			],
+			"match": {
+				"duration=*": "Last seen {formattedDuration}."
+			}
+		}
+	],
+	"relative_update": [
+		{
+			"declarations": [
+				"input duration",
+				"input unit",
+				"local formattedDuration = duration: relativetime unit=$unit style=short"
+			],
+			"match": {
+				"duration=*,unit=*": "Updated {formattedDuration}."
+			}
+		}
 	]
 }

--- a/examples/formatting/src/main.ts
+++ b/examples/formatting/src/main.ts
@@ -48,3 +48,85 @@ test("formats dates using locale-specific ordering", async () => {
 	setLocale("de");
 	assert.strictEqual(m.purchase_date({ date }), "Kaufdatum: 01.04.2022.");
 });
+
+test("formats relative times with literal units and numeric auto", async () => {
+	setLocale("en");
+	assert.strictEqual(
+		m.last_seen({ duration: -1 }),
+		`Last seen ${formatRelativeTime("en", -1, "day", { numeric: "auto" })}.`
+	);
+
+	setLocale("de");
+	assert.strictEqual(
+		m.last_seen({ duration: -1 }),
+		`Zuletzt gesehen: ${formatRelativeTime("de", -1, "day", {
+			numeric: "auto",
+		})}.`
+	);
+});
+
+test("formats relative times with dynamic units and style options", async () => {
+	setLocale("en");
+	assert.strictEqual(
+		m.relative_update({ duration: -3, unit: "hours" }),
+		`Updated ${formatRelativeTime("en", -3, "hours", { style: "short" })}.`
+	);
+
+	setLocale("de");
+	assert.strictEqual(
+		m.relative_update({ duration: 2, unit: "week" }),
+		`Aktualisiert ${formatRelativeTime("de", 2, "week", {
+			style: "short",
+		})}.`
+	);
+});
+
+test("formats relative times after caller-side threshold selection", async () => {
+	setLocale("en");
+
+	for (const minutes of [-45, -125, -60 * 24 * 2]) {
+		const input = toRelativeDuration(minutes);
+
+		assert.strictEqual(
+			m.relative_update(input),
+			`Updated ${formatRelativeTime("en", input.duration, input.unit, {
+				style: "short",
+			})}.`
+		);
+	}
+});
+
+function toRelativeDuration(minutes: number) {
+	const absoluteMinutes = Math.abs(minutes);
+
+	if (absoluteMinutes >= 60 * 24) {
+		return {
+			duration: Math.round(minutes / (60 * 24)),
+			unit: "day",
+		};
+	}
+
+	if (absoluteMinutes >= 60) {
+		return {
+			duration: Math.round(minutes / 60),
+			unit: "hour",
+		};
+	}
+
+	return {
+		duration: minutes,
+		unit: "minute",
+	};
+}
+
+function formatRelativeTime(
+	locale: string,
+	duration: number,
+	unit: string,
+	options: Intl.RelativeTimeFormatOptions = {}
+) {
+	return new Intl.RelativeTimeFormat(locale, options).format(
+		duration,
+		unit as Intl.RelativeTimeFormatUnit
+	);
+}

--- a/examples/formatting/src/main.ts
+++ b/examples/formatting/src/main.ts
@@ -53,15 +53,13 @@ test("formats relative times with literal units and numeric auto", async () => {
 	setLocale("en");
 	assert.strictEqual(
 		m.last_seen({ duration: -1 }),
-		`Last seen ${formatRelativeTime("en", -1, "day", { numeric: "auto" })}.`
+		"Last seen yesterday."
 	);
 
 	setLocale("de");
 	assert.strictEqual(
 		m.last_seen({ duration: -1 }),
-		`Zuletzt gesehen: ${formatRelativeTime("de", -1, "day", {
-			numeric: "auto",
-		})}.`
+		"Zuletzt gesehen: gestern."
 	);
 });
 
@@ -69,64 +67,31 @@ test("formats relative times with dynamic units and style options", async () => 
 	setLocale("en");
 	assert.strictEqual(
 		m.relative_update({ duration: -3, unit: "hours" }),
-		`Updated ${formatRelativeTime("en", -3, "hours", { style: "short" })}.`
+		"Updated 3 hr. ago."
 	);
 
 	setLocale("de");
 	assert.strictEqual(
 		m.relative_update({ duration: 2, unit: "week" }),
-		`Aktualisiert ${formatRelativeTime("de", 2, "week", {
-			style: "short",
-		})}.`
+		"Aktualisiert in 2 Wochen."
 	);
 });
 
 test("formats relative times after caller-side threshold selection", async () => {
 	setLocale("en");
 
-	for (const minutes of [-45, -125, -60 * 24 * 2]) {
-		const input = toRelativeDuration(minutes);
-
-		assert.strictEqual(
-			m.relative_update(input),
-			`Updated ${formatRelativeTime("en", input.duration, input.unit, {
-				style: "short",
-			})}.`
-		);
-	}
-});
-
-function toRelativeDuration(minutes: number) {
-	const absoluteMinutes = Math.abs(minutes);
-
-	if (absoluteMinutes >= 60 * 24) {
-		return {
-			duration: Math.round(minutes / (60 * 24)),
-			unit: "day",
-		};
-	}
-
-	if (absoluteMinutes >= 60) {
-		return {
-			duration: Math.round(minutes / 60),
-			unit: "hour",
-		};
-	}
-
-	return {
-		duration: minutes,
-		unit: "minute",
-	};
-}
-
-function formatRelativeTime(
-	locale: string,
-	duration: number,
-	unit: string,
-	options: Intl.RelativeTimeFormatOptions = {}
-) {
-	return new Intl.RelativeTimeFormat(locale, options).format(
-		duration,
-		unit as Intl.RelativeTimeFormatUnit
+	assert.strictEqual(
+		m.relative_update({ duration: -45, unit: "minute" }),
+		"Updated 45 min. ago."
 	);
-}
+
+	assert.strictEqual(
+		m.relative_update({ duration: -2, unit: "hour" }),
+		"Updated 2 hr. ago."
+	);
+
+	assert.strictEqual(
+		m.relative_update({ duration: -2, unit: "day" }),
+		"Updated 2 days ago."
+	);
+});

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -361,3 +361,28 @@ test("accepts dynamic relative time formatter units", () => {
 		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
 	);
 });
+
+test("accepts dollar-prefixed relative time formatter unit options from message files", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{ name: "unit", value: { type: "literal", value: "$unit" } },
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
+	);
+});

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -178,3 +178,129 @@ test("keeps negative digit options as strings to avoid emitting invalid numeric 
 		'const formattedValue = registry.number("en", i?.value, { minimumFractionDigits: "-1" });'
 	);
 });
+
+test("compiles relative time formatter with a literal unit", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{ name: "unit", value: { type: "literal", value: "day" } },
+						{ name: "numeric", value: { type: "literal", value: "auto" } },
+						{
+							name: "numberingSystem",
+							value: { type: "literal", value: "latn" },
+						},
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: "day", numeric: "auto", numberingSystem: "latn" });'
+	);
+});
+
+test("compiles relative time formatter with a dynamic unit cast", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{
+							name: "unit",
+							value: { type: "variable-reference", name: "unit" },
+						},
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
+	);
+});
+
+test("throws if relative time formatter is missing a unit option", () => {
+	expect(() =>
+		compileLocalVariable({
+			locale: "en",
+			declaration: {
+				type: "local-variable",
+				name: "formattedDuration",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "duration" },
+					annotation: {
+						type: "function-reference",
+						name: "relativetime",
+						options: [],
+					},
+				},
+			},
+		})
+	).toThrow('The "relativetime" formatter requires a "unit" option.');
+});
+
+test("throws if relative time formatter has duplicate unit options", () => {
+	expect(() =>
+		compileLocalVariable({
+			locale: "en",
+			declaration: {
+				type: "local-variable",
+				name: "formattedDuration",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "duration" },
+					annotation: {
+						type: "function-reference",
+						name: "relativetime",
+						options: [
+							{ name: "unit", value: { type: "literal", value: "day" } },
+							{ name: "unit", value: { type: "literal", value: "hour" } },
+						],
+					},
+				},
+			},
+		})
+	).toThrow('The "relativetime" formatter requires exactly one "unit" option.');
+});
+
+test("throws if relative time formatter has an invalid literal unit", () => {
+	expect(() =>
+		compileLocalVariable({
+			locale: "en",
+			declaration: {
+				type: "local-variable",
+				name: "formattedDuration",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "duration" },
+					annotation: {
+						type: "function-reference",
+						name: "relativetime",
+						options: [
+							{ name: "unit", value: { type: "literal", value: "weekday" } },
+						],
+					},
+				},
+			},
+		})
+	).toThrow('Invalid "relativetime" unit "weekday".');
+});

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -227,8 +227,8 @@ test("compiles relative time formatter with a dynamic unit cast", () => {
 							value: { type: "variable-reference", name: "unit" },
 						},
 						{
-							name: "numberingSystem",
-							value: { type: "literal", value: "latn" },
+							name: "style",
+							value: { type: "literal", value: "short" },
 						},
 					],
 				},
@@ -237,7 +237,7 @@ test("compiles relative time formatter with a dynamic unit cast", () => {
 	});
 
 	expect(code).toEqual(
-		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit), numberingSystem: "latn" });'
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit), style: "short" });'
 	);
 });
 

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -195,8 +195,8 @@ test("compiles relative time formatter with a literal unit", () => {
 						{ name: "unit", value: { type: "literal", value: "day" } },
 						{ name: "numeric", value: { type: "literal", value: "auto" } },
 						{
-							name: "numberingSystem",
-							value: { type: "literal", value: "latn" },
+							name: "style",
+							value: { type: "literal", value: "short" },
 						},
 					],
 				},
@@ -205,7 +205,7 @@ test("compiles relative time formatter with a literal unit", () => {
 	});
 
 	expect(code).toEqual(
-		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: "day", numeric: "auto", numberingSystem: "latn" });'
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: "day", numeric: "auto", style: "short" });'
 	);
 });
 
@@ -226,6 +226,10 @@ test("compiles relative time formatter with a dynamic unit cast", () => {
 							name: "unit",
 							value: { type: "variable-reference", name: "unit" },
 						},
+						{
+							name: "numberingSystem",
+							value: { type: "literal", value: "latn" },
+						},
 					],
 				},
 			},
@@ -233,7 +237,7 @@ test("compiles relative time formatter with a dynamic unit cast", () => {
 	});
 
 	expect(code).toEqual(
-		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit), numberingSystem: "latn" });'
 	);
 });
 
@@ -296,11 +300,64 @@ test("throws if relative time formatter has an invalid literal unit", () => {
 						type: "function-reference",
 						name: "relativetime",
 						options: [
-							{ name: "unit", value: { type: "literal", value: "weekday" } },
+							{ name: "unit", value: { type: "literal", value: "century" } },
 						],
 					},
 				},
 			},
 		})
-	).toThrow('Invalid "relativetime" unit "weekday".');
+	).toThrow('Invalid "relativetime" unit "century".');
+});
+
+test("accepts plural relative time formatter units", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{ name: "unit", value: { type: "literal", value: "days" } },
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: "days" });'
+	);
+});
+
+test("accepts dynamic relative time formatter units", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{
+							name: "unit",
+							value: { type: "variable-reference", name: "unit" },
+						},
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
+	);
 });

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -194,10 +194,7 @@ test("compiles relative time formatter with a literal unit", () => {
 					options: [
 						{ name: "unit", value: { type: "literal", value: "day" } },
 						{ name: "numeric", value: { type: "literal", value: "auto" } },
-						{
-							name: "style",
-							value: { type: "literal", value: "short" },
-						},
+						{ name: "style", value: { type: "literal", value: "short" } },
 					],
 				},
 			},
@@ -226,10 +223,7 @@ test("compiles relative time formatter with a dynamic unit cast", () => {
 							name: "unit",
 							value: { type: "variable-reference", name: "unit" },
 						},
-						{
-							name: "style",
-							value: { type: "literal", value: "short" },
-						},
+						{ name: "style", value: { type: "literal", value: "short" } },
 					],
 				},
 			},

--- a/src/compiler/compile-local-variable.test.ts
+++ b/src/compiler/compile-local-variable.test.ts
@@ -386,3 +386,31 @@ test("accepts dollar-prefixed relative time formatter unit options from message 
 		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit) });'
 	);
 });
+
+test("accepts dollar-prefixed relative time formatter unit options with non-identifier input names", () => {
+	const code = compileLocalVariable({
+		locale: "en",
+		declaration: {
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				type: "expression",
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: [
+						{
+							name: "unit",
+							value: { type: "literal", value: "$relative-unit" },
+						},
+					],
+				},
+			},
+		},
+	});
+
+	expect(code).toEqual(
+		'const formattedDuration = registry.relativetime("en", i?.duration, { unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.["relative-unit"]) });'
+	);
+});

--- a/src/compiler/compile-local-variable.ts
+++ b/src/compiler/compile-local-variable.ts
@@ -105,6 +105,14 @@ function compileOptionLiteralOrVarRef(
 		return compileInputAccess(value.name);
 	}
 
+	if (
+		annotationName === "relativetime" &&
+		optionName === "unit" &&
+		isDollarVariableReference(value.value)
+	) {
+		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.value.slice(1))})`;
+	}
+
 	if (shouldEmitNumberLiteral(annotationName, optionName, value.value)) {
 		return value.value;
 	}
@@ -186,6 +194,10 @@ function validateRelativeTimeOptions(annotation: FunctionReference): void {
 		return;
 	}
 
+	if (isDollarVariableReference(unitOption.value.value)) {
+		return;
+	}
+
 	if (!relativeTimeUnits.has(unitOption.value.value)) {
 		throw new Error(
 			`Invalid "relativetime" unit "${unitOption.value.value}". Expected one of: ${Array.from(
@@ -193,4 +205,8 @@ function validateRelativeTimeOptions(annotation: FunctionReference): void {
 			).join(", ")}.`
 		);
 	}
+}
+
+function isDollarVariableReference(value: string): boolean {
+	return /^\$[A-Za-z_$][A-Za-z0-9_$]*$/.test(value);
 }

--- a/src/compiler/compile-local-variable.ts
+++ b/src/compiler/compile-local-variable.ts
@@ -208,5 +208,5 @@ function validateRelativeTimeOptions(annotation: FunctionReference): void {
 }
 
 function isDollarVariableReference(value: string): boolean {
-	return /^\$[A-Za-z_$][A-Za-z0-9_$]*$/.test(value);
+	return value.startsWith("$") && value.length > 1;
 }

--- a/src/compiler/compile-local-variable.ts
+++ b/src/compiler/compile-local-variable.ts
@@ -41,6 +41,9 @@ function compileAnnotation(
 	if (!annotation) {
 		return str;
 	}
+	if (annotation.name === "relativetime") {
+		validateRelativeTimeOptions(annotation);
+	}
 	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options)})`;
 }
 
@@ -96,6 +99,9 @@ function compileOptionLiteralOrVarRef(
 	value: Literal | VariableReference
 ): string {
 	if (value.type === "variable-reference") {
+		if (annotationName === "relativetime" && optionName === "unit") {
+			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.name)})`;
+		}
 		return compileInputAccess(value.name);
 	}
 
@@ -138,5 +144,53 @@ function compileLiteralOrVarRef(value: Literal | VariableReference): string {
 			return `"${escapeForDoubleQuoteString(value.value)}"`;
 		case "variable-reference":
 			return compileInputAccess(value.name);
+	}
+}
+
+const relativeTimeUnits = new Set([
+	"year",
+	"years",
+	"quarter",
+	"quarters",
+	"month",
+	"months",
+	"week",
+	"weeks",
+	"day",
+	"days",
+	"hour",
+	"hours",
+	"minute",
+	"minutes",
+	"second",
+	"seconds",
+]);
+
+function validateRelativeTimeOptions(annotation: FunctionReference): void {
+	const unitOptions = annotation.options.filter(
+		(option) => option.name === "unit"
+	);
+
+	if (unitOptions.length === 0) {
+		throw new Error('The "relativetime" formatter requires a "unit" option.');
+	}
+
+	if (unitOptions.length > 1) {
+		throw new Error(
+			'The "relativetime" formatter requires exactly one "unit" option.'
+		);
+	}
+
+	const [unitOption] = unitOptions;
+	if (!unitOption || unitOption.value.type === "variable-reference") {
+		return;
+	}
+
+	if (!relativeTimeUnits.has(unitOption.value.value)) {
+		throw new Error(
+			`Invalid "relativetime" unit "${unitOption.value.value}". Expected one of: ${Array.from(
+				relativeTimeUnits
+			).join(", ")}.`
+		);
 	}
 }

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -1,11 +1,6 @@
 import { test, expect } from "vitest";
 import { compileMessage } from "./compile-message.js";
-import type {
-	Declaration,
-	FunctionReference,
-	Message,
-	Variant,
-} from "@inlang/sdk";
+import type { Declaration, Message, Variant } from "@inlang/sdk";
 import { createRegistry } from "./registry.js";
 
 test("compiles a message with a single variant", async () => {
@@ -861,10 +856,84 @@ test("compiles messages that use datetime a function with options", async () => 
 	);
 });
 
-async function createRelativeTimeMessage(args: {
-	locale: string;
-	options: FunctionReference["options"];
-}) {
+test("compiles messages that use relativetime() with options", async () => {
+	const createMessage = async (locale: string) => {
+		const declarations: Declaration[] = [
+			{ type: "input-variable", name: "duration" },
+			{
+				type: "local-variable",
+				name: "formattedDuration",
+				value: {
+					arg: { type: "variable-reference", name: "duration" },
+					annotation: {
+						type: "function-reference",
+						name: "relativetime",
+						options: [
+							{ name: "unit", value: { type: "literal", value: "day" } },
+							{ name: "numeric", value: { type: "literal", value: "auto" } },
+							{ name: "style", value: { type: "literal", value: "short" } },
+						],
+					},
+					type: "expression",
+				},
+			},
+		];
+
+		const message: Message = {
+			locale,
+			bundleId: "relative_time_test",
+			id: "message_id",
+			selectors: [],
+		};
+
+		const variants: Variant[] = [
+			{
+				id: "1",
+				messageId: "message_id",
+				matches: [],
+				pattern: [
+					{ type: "text", value: "Updated " },
+					{
+						type: "expression",
+						arg: { type: "variable-reference", name: "formattedDuration" },
+					},
+					{ type: "text", value: "." },
+				],
+			},
+		];
+
+		const compiled = compileMessage(declarations, message, variants);
+
+		const { relative_time_test } = await import(
+			"data:text/javascript;base64," +
+				// bundling the registry inline to avoid managing module imports here
+				btoa(createRegistry()) +
+				btoa(
+					"export const relative_time_test = " +
+						compiled.code.replace("registry.", "")
+				)
+		);
+		return relative_time_test;
+	};
+
+	const enMessage = await createMessage("en");
+	const deMessage = await createMessage("de");
+
+	expect(enMessage({ duration: -1 })).toBe(
+		`Updated ${new Intl.RelativeTimeFormat("en", {
+			numeric: "auto",
+			style: "short",
+		}).format(-1, "day")}.`
+	);
+	expect(deMessage({ duration: 2 })).toBe(
+		`Updated ${new Intl.RelativeTimeFormat("de", {
+			numeric: "auto",
+			style: "short",
+		}).format(2, "day")}.`
+	);
+});
+
+test("compiles messages that use relativetime() with dynamic units", async () => {
 	const declarations: Declaration[] = [
 		{ type: "input-variable", name: "duration" },
 		{ type: "input-variable", name: "unit" },
@@ -876,7 +945,13 @@ async function createRelativeTimeMessage(args: {
 				annotation: {
 					type: "function-reference",
 					name: "relativetime",
-					options: args.options,
+					options: [
+						{
+							name: "unit",
+							value: { type: "variable-reference", name: "unit" },
+						},
+						{ name: "style", value: { type: "literal", value: "short" } },
+					],
 				},
 				type: "expression",
 			},
@@ -884,7 +959,7 @@ async function createRelativeTimeMessage(args: {
 	];
 
 	const message: Message = {
-		locale: args.locale,
+		locale: "en",
 		bundleId: "relative_time_test",
 		id: "message_id",
 		selectors: [],
@@ -910,6 +985,7 @@ async function createRelativeTimeMessage(args: {
 
 	const { relative_time_test } = await import(
 		"data:text/javascript;base64," +
+			// bundling the registry inline to avoid managing module imports here
 			btoa(createRegistry()) +
 			btoa(
 				"export const relative_time_test = " +
@@ -917,141 +993,11 @@ async function createRelativeTimeMessage(args: {
 			)
 	);
 
-	return relative_time_test as (input: {
-		duration: number;
-		unit?: string;
-	}) => string;
-}
-
-function expectedRelativeTime(
-	locale: string,
-	duration: number,
-	unit: string,
-	options: Intl.RelativeTimeFormatOptions = {}
-) {
-	return `Updated ${new Intl.RelativeTimeFormat(locale, options).format(
-		duration,
-		unit as Intl.RelativeTimeFormatUnit
-	)}.`;
-}
-
-test("compiles messages that use relativetime() for past and future values", async () => {
-	const message = await createRelativeTimeMessage({
-		locale: "en",
-		options: [{ name: "unit", value: { type: "literal", value: "day" } }],
-	});
-
-	expect(message({ duration: -3 })).toBe(expectedRelativeTime("en", -3, "day"));
-	expect(message({ duration: 2 })).toBe(expectedRelativeTime("en", 2, "day"));
-});
-
-test("compiles messages that use relativetime() with numeric auto", async () => {
-	const message = await createRelativeTimeMessage({
-		locale: "en",
-		options: [
-			{ name: "unit", value: { type: "literal", value: "day" } },
-			{ name: "numeric", value: { type: "literal", value: "auto" } },
-		],
-	});
-
-	expect(message({ duration: -1 })).toBe(
-		expectedRelativeTime("en", -1, "day", { numeric: "auto" })
+	expect(relative_time_test({ duration: -3, unit: "hour" })).toBe(
+		`Updated ${new Intl.RelativeTimeFormat("en", {
+			style: "short",
+		}).format(-3, "hour")}.`
 	);
-});
-
-test("compiles messages that use relativetime() styles", async () => {
-	for (const style of ["long", "short", "narrow"] as const) {
-		const message = await createRelativeTimeMessage({
-			locale: "en",
-			options: [
-				{ name: "unit", value: { type: "literal", value: "hour" } },
-				{ name: "style", value: { type: "literal", value: style } },
-			],
-		});
-
-		expect(message({ duration: -4 })).toBe(
-			expectedRelativeTime("en", -4, "hour", { style })
-		);
-	}
-});
-
-test("compiles messages that use relativetime() singular and plural units", async () => {
-	const singularMessage = await createRelativeTimeMessage({
-		locale: "en",
-		options: [{ name: "unit", value: { type: "literal", value: "day" } }],
-	});
-	const pluralMessage = await createRelativeTimeMessage({
-		locale: "en",
-		options: [{ name: "unit", value: { type: "literal", value: "days" } }],
-	});
-
-	expect(singularMessage({ duration: 2 })).toBe(
-		expectedRelativeTime("en", 2, "day")
-	);
-	expect(pluralMessage({ duration: 2 })).toBe(
-		expectedRelativeTime("en", 2, "days")
-	);
-});
-
-test("compiles messages that use relativetime() dynamic units", async () => {
-	const message = await createRelativeTimeMessage({
-		locale: "en",
-		options: [
-			{ name: "unit", value: { type: "variable-reference", name: "unit" } },
-			{ name: "style", value: { type: "literal", value: "short" } },
-		],
-	});
-
-	expect(message({ duration: -3, unit: "hour" })).toBe(
-		expectedRelativeTime("en", -3, "hour", { style: "short" })
-	);
-});
-
-test("compiles relativetime() messages for caller-side threshold selection", async () => {
-	const message = await createRelativeTimeMessage({
-		locale: "en",
-		options: [
-			{ name: "unit", value: { type: "variable-reference", name: "unit" } },
-			{ name: "style", value: { type: "literal", value: "short" } },
-		],
-	});
-	const toRelativeDuration = (minutes: number) => {
-		const absoluteMinutes = Math.abs(minutes);
-
-		if (absoluteMinutes >= 60 * 24) {
-			return { duration: Math.round(minutes / (60 * 24)), unit: "day" };
-		}
-
-		if (absoluteMinutes >= 60) {
-			return { duration: Math.round(minutes / 60), unit: "hour" };
-		}
-
-		return { duration: minutes, unit: "minute" };
-	};
-
-	for (const minutes of [-45, -125, -60 * 24 * 2]) {
-		const input = toRelativeDuration(minutes);
-
-		expect(message(input)).toBe(
-			expectedRelativeTime("en", input.duration, input.unit, { style: "short" })
-		);
-	}
-});
-
-test("compiles messages that use relativetime() for multiple locales", async () => {
-	for (const locale of ["en", "de", "fr"]) {
-		const message = await createRelativeTimeMessage({
-			locale,
-			options: [
-				{ name: "unit", value: { type: "literal", value: "month" } },
-				{ name: "numeric", value: { type: "literal", value: "always" } },
-			],
-		});
-
-		expect(message({ duration: 1 })).toBe(
-			expectedRelativeTime(locale, 1, "month", { numeric: "always" })
-		);
-	}
 });
 
 test("does not throw when input is omitted for a single-variant message", async () => {

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -919,18 +919,8 @@ test("compiles messages that use relativetime() with options", async () => {
 	const enMessage = await createMessage("en");
 	const deMessage = await createMessage("de");
 
-	expect(enMessage({ duration: -1 })).toBe(
-		`Updated ${new Intl.RelativeTimeFormat("en", {
-			numeric: "auto",
-			style: "short",
-		}).format(-1, "day")}.`
-	);
-	expect(deMessage({ duration: 2 })).toBe(
-		`Updated ${new Intl.RelativeTimeFormat("de", {
-			numeric: "auto",
-			style: "short",
-		}).format(2, "day")}.`
-	);
+	expect(enMessage({ duration: -1 })).toBe("Updated yesterday.");
+	expect(deMessage({ duration: 2 })).toBe("Updated übermorgen.");
 });
 
 test("compiles messages that use relativetime() with dynamic units", async () => {
@@ -994,9 +984,7 @@ test("compiles messages that use relativetime() with dynamic units", async () =>
 	);
 
 	expect(relative_time_test({ duration: -3, unit: "hour" })).toBe(
-		`Updated ${new Intl.RelativeTimeFormat("en", {
-			style: "short",
-		}).format(-3, "hour")}.`
+		"Updated 3 hr. ago."
 	);
 });
 

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "vitest";
 import { compileMessage } from "./compile-message.js";
-import type { Declaration, Message, Variant } from "@inlang/sdk";
+import type {
+	Declaration,
+	FunctionReference,
+	Message,
+	Variant,
+} from "@inlang/sdk";
 import { createRegistry } from "./registry.js";
 
 test("compiles a message with a single variant", async () => {
@@ -854,6 +859,213 @@ test("compiles messages that use datetime a function with options", async () => 
 	expect(deMessage({ date: "2022-03-31" })).toMatch(
 		/Today is \d{1,2}\. März\./
 	);
+});
+
+async function createRelativeTimeMessage(args: {
+	locale: string;
+	options: FunctionReference["options"];
+}) {
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "duration" },
+		{ type: "input-variable", name: "unit" },
+		{
+			type: "local-variable",
+			name: "formattedDuration",
+			value: {
+				arg: { type: "variable-reference", name: "duration" },
+				annotation: {
+					type: "function-reference",
+					name: "relativetime",
+					options: args.options,
+				},
+				type: "expression",
+			},
+		},
+	];
+
+	const message: Message = {
+		locale: args.locale,
+		bundleId: "relative_time_test",
+		id: "message_id",
+		selectors: [],
+	};
+
+	const variants: Variant[] = [
+		{
+			id: "1",
+			messageId: "message_id",
+			matches: [],
+			pattern: [
+				{ type: "text", value: "Updated " },
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "formattedDuration" },
+				},
+				{ type: "text", value: "." },
+			],
+		},
+	];
+
+	const compiled = compileMessage(declarations, message, variants);
+
+	const { relative_time_test } = await import(
+		"data:text/javascript;base64," +
+			btoa(createRegistry()) +
+			btoa(
+				"export const relative_time_test = " +
+					compiled.code.replace("registry.", "")
+			)
+	);
+
+	return relative_time_test as (input: {
+		duration: number;
+		unit?: string;
+	}) => string;
+}
+
+function expectedRelativeTime(
+	locale: string,
+	duration: number,
+	unit: string,
+	options: Intl.RelativeTimeFormatOptions & { numberingSystem?: string } = {}
+) {
+	return `Updated ${new Intl.RelativeTimeFormat(locale, options).format(
+		duration,
+		unit as Intl.RelativeTimeFormatUnit
+	)}.`;
+}
+
+test("compiles messages that use relativetime() for past and future values", async () => {
+	const message = await createRelativeTimeMessage({
+		locale: "en",
+		options: [{ name: "unit", value: { type: "literal", value: "day" } }],
+	});
+
+	expect(message({ duration: -3 })).toBe(expectedRelativeTime("en", -3, "day"));
+	expect(message({ duration: 2 })).toBe(expectedRelativeTime("en", 2, "day"));
+});
+
+test("compiles messages that use relativetime() with numeric auto", async () => {
+	const message = await createRelativeTimeMessage({
+		locale: "en",
+		options: [
+			{ name: "unit", value: { type: "literal", value: "day" } },
+			{ name: "numeric", value: { type: "literal", value: "auto" } },
+		],
+	});
+
+	expect(message({ duration: -1 })).toBe(
+		expectedRelativeTime("en", -1, "day", { numeric: "auto" })
+	);
+});
+
+test("compiles messages that use relativetime() styles", async () => {
+	for (const style of ["long", "short", "narrow"] as const) {
+		const message = await createRelativeTimeMessage({
+			locale: "en",
+			options: [
+				{ name: "unit", value: { type: "literal", value: "hour" } },
+				{ name: "style", value: { type: "literal", value: style } },
+			],
+		});
+
+		expect(message({ duration: -4 })).toBe(
+			expectedRelativeTime("en", -4, "hour", { style })
+		);
+	}
+});
+
+test("compiles messages that use relativetime() numberingSystem", async () => {
+	const message = await createRelativeTimeMessage({
+		locale: "ar",
+		options: [
+			{ name: "unit", value: { type: "literal", value: "day" } },
+			{ name: "numberingSystem", value: { type: "literal", value: "latn" } },
+		],
+	});
+
+	expect(message({ duration: 12 })).toBe(
+		expectedRelativeTime("ar", 12, "day", { numberingSystem: "latn" })
+	);
+});
+
+test("compiles messages that use relativetime() singular and plural units", async () => {
+	const singularMessage = await createRelativeTimeMessage({
+		locale: "en",
+		options: [{ name: "unit", value: { type: "literal", value: "day" } }],
+	});
+	const pluralMessage = await createRelativeTimeMessage({
+		locale: "en",
+		options: [{ name: "unit", value: { type: "literal", value: "days" } }],
+	});
+
+	expect(singularMessage({ duration: 2 })).toBe(
+		expectedRelativeTime("en", 2, "day")
+	);
+	expect(pluralMessage({ duration: 2 })).toBe(
+		expectedRelativeTime("en", 2, "days")
+	);
+});
+
+test("compiles messages that use relativetime() dynamic units", async () => {
+	const message = await createRelativeTimeMessage({
+		locale: "en",
+		options: [
+			{ name: "unit", value: { type: "variable-reference", name: "unit" } },
+			{ name: "style", value: { type: "literal", value: "short" } },
+		],
+	});
+
+	expect(message({ duration: -3, unit: "hour" })).toBe(
+		expectedRelativeTime("en", -3, "hour", { style: "short" })
+	);
+});
+
+test("compiles relativetime() messages for caller-side threshold selection", async () => {
+	const message = await createRelativeTimeMessage({
+		locale: "en",
+		options: [
+			{ name: "unit", value: { type: "variable-reference", name: "unit" } },
+			{ name: "style", value: { type: "literal", value: "short" } },
+		],
+	});
+	const toRelativeDuration = (minutes: number) => {
+		const absoluteMinutes = Math.abs(minutes);
+
+		if (absoluteMinutes >= 60 * 24) {
+			return { duration: Math.round(minutes / (60 * 24)), unit: "day" };
+		}
+
+		if (absoluteMinutes >= 60) {
+			return { duration: Math.round(minutes / 60), unit: "hour" };
+		}
+
+		return { duration: minutes, unit: "minute" };
+	};
+
+	for (const minutes of [-45, -125, -60 * 24 * 2]) {
+		const input = toRelativeDuration(minutes);
+
+		expect(message(input)).toBe(
+			expectedRelativeTime("en", input.duration, input.unit, { style: "short" })
+		);
+	}
+});
+
+test("compiles messages that use relativetime() for multiple locales", async () => {
+	for (const locale of ["en", "de", "fr"]) {
+		const message = await createRelativeTimeMessage({
+			locale,
+			options: [
+				{ name: "unit", value: { type: "literal", value: "month" } },
+				{ name: "numeric", value: { type: "literal", value: "always" } },
+			],
+		});
+
+		expect(message({ duration: 1 })).toBe(
+			expectedRelativeTime(locale, 1, "month", { numeric: "always" })
+		);
+	}
 });
 
 test("does not throw when input is omitted for a single-variant message", async () => {

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -927,7 +927,7 @@ function expectedRelativeTime(
 	locale: string,
 	duration: number,
 	unit: string,
-	options: Intl.RelativeTimeFormatOptions & { numberingSystem?: string } = {}
+	options: Intl.RelativeTimeFormatOptions = {}
 ) {
 	return `Updated ${new Intl.RelativeTimeFormat(locale, options).format(
 		duration,
@@ -973,20 +973,6 @@ test("compiles messages that use relativetime() styles", async () => {
 			expectedRelativeTime("en", -4, "hour", { style })
 		);
 	}
-});
-
-test("compiles messages that use relativetime() numberingSystem", async () => {
-	const message = await createRelativeTimeMessage({
-		locale: "ar",
-		options: [
-			{ name: "unit", value: { type: "literal", value: "day" } },
-			{ name: "numberingSystem", value: { type: "literal", value: "latn" } },
-		],
-	});
-
-	expect(message({ duration: 12 })).toBe(
-		expectedRelativeTime("ar", 12, "day", { numberingSystem: "latn" })
-	);
 });
 
 test("compiles messages that use relativetime() singular and plural units", async () => {

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -920,9 +920,9 @@ describe.each([
 				compilerOptions.outputStructure === "locale-modules"
 					? "messages/en.js"
 					: "messages/relative_time_dynamic.js";
-			const relativeTimeDynamicModule = output[relativeTimeDynamicFile]!;
 
 			expect(output).toHaveProperty(relativeTimeDynamicFile);
+			const relativeTimeDynamicModule = output[relativeTimeDynamicFile]!;
 			expect(relativeTimeDynamicModule).toContain(
 				'unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit)'
 			);
@@ -1048,10 +1048,10 @@ describe.each([
     // a message without params shouldn't require params
     m.sad_penguin_bundle() satisfies string
 
-		// dynamic relativetime unit inputs stay consistent with other formatter inputs
-		m.relative_time_literal({ duration: -1 }) satisfies string
-		m.relative_time_dynamic({ duration: -3, unit: "hour" }) satisfies string
-		m.relative_time_dynamic({ duration: -3, unit: "fortnight" }) satisfies string
+    // dynamic relativetime unit inputs stay consistent with other formatter inputs
+    m.relative_time_literal({ duration: -1 }) satisfies string
+    m.relative_time_dynamic({ duration: -3, unit: "hour" }) satisfies string
+    m.relative_time_dynamic({ duration: -3, unit: "not-a-relative-time-unit" }) satisfies string
 
 		// --------- MATCH TYPE INFERENCE ---------
 		// known match values should be accepted

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -228,7 +228,11 @@ test("emitTsDeclarations generates declaration files", async () => {
 
 	expect(output).toHaveProperty("messages/_index.d.ts");
 	expect(output).toHaveProperty("messages.d.ts");
+	expect(output).toHaveProperty("registry.d.ts");
 	expect(output["messages/_index.d.ts"]).toContain("sad_penguin_bundle");
+	expect(output["messages/_index.d.ts"]).toContain("relative_time_dynamic");
+	expect(output["registry.d.ts"]).toContain("RelativeTimeFormatUnit");
+	expect(output["registry.d.ts"]).toContain("relativetime");
 });
 
 test("handles message bundles with a : in the id", async () => {
@@ -658,6 +662,38 @@ describe.each([
 				);
 			});
 
+			test("relativetime formatter works with literal units and locale overrides", async () => {
+				const { m, runtime } = await importCode(code);
+
+				runtime.setLocale("de");
+				expect(m.relative_time_literal({ duration: -1 })).toBe(
+					expectedRelativeTimeMessage("de", -1, "day", { numeric: "auto" })
+				);
+				expect(
+					m.relative_time_literal({ duration: -1 }, { locale: "en" })
+				).toBe(
+					expectedRelativeTimeMessage("en", -1, "day", { numeric: "auto" })
+				);
+			});
+
+			test("relativetime formatter works with dynamic units", async () => {
+				const { m, runtime } = await importCode(code);
+
+				runtime.setLocale("en");
+				expect(m.relative_time_dynamic({ duration: -3, unit: "hour" })).toBe(
+					expectedRelativeTimeMessage("en", -3, "hour", {
+						style: "short",
+					})
+				);
+
+				runtime.setLocale("de");
+				expect(m.relative_time_dynamic({ duration: 2, unit: "weeks" })).toBe(
+					expectedRelativeTimeMessage("de", 2, "weeks", {
+						style: "short",
+					})
+				);
+			});
+
 			test("runtime.isLocale should only return `true` if a locale is passed to it", async () => {
 				const { runtime } = await importCode(code);
 
@@ -852,6 +888,17 @@ describe.each([
 			});
 		});
 
+		test("relativetime dynamic unit casts generated options without narrowing public inputs", () => {
+			const generatedOutput = Object.values(output).join("\n");
+
+			expect(generatedOutput).toContain(
+				'unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit)'
+			);
+			expect(generatedOutput).toContain(
+				"{ duration: NonNullable<unknown>, unit: NonNullable<unknown> }"
+			);
+		});
+
 		test("case sensitivity handling for bundle IDs", async () => {
 			const project = await loadProjectInMemory({
 				blob: await newProject({
@@ -968,6 +1015,11 @@ describe.each([
 
     // a message without params shouldn't require params
     m.sad_penguin_bundle() satisfies string
+
+		// dynamic relativetime unit inputs stay consistent with other formatter inputs
+		m.relative_time_literal({ duration: -1 }) satisfies string
+		m.relative_time_dynamic({ duration: -3, unit: "hour" }) satisfies string
+		m.relative_time_dynamic({ duration: -3, unit: "fortnight" }) satisfies string
 
 		// --------- MATCH TYPE INFERENCE ---------
 		// known match values should be accepted
@@ -1198,6 +1250,102 @@ describe.each([
 			}
 			expect(diagnostics.length).toEqual(0);
 		});
+
+		test("relativetime formatter options should pass checkJs", async () => {
+			const projectWithRelativeTimeOptions = await loadProjectInMemory({
+				blob: await newProject({
+					settings: {
+						baseLocale: "en",
+						locales: ["en"],
+					},
+				}),
+			});
+
+			await insertBundleNested(
+				projectWithRelativeTimeOptions.db,
+				createBundleNested({
+					id: "formatted_relative_time",
+					declarations: [
+						{
+							type: "input-variable",
+							name: "duration",
+						},
+						{
+							type: "input-variable",
+							name: "unit",
+						},
+						{
+							type: "local-variable",
+							name: "formattedDuration",
+							value: {
+								type: "expression",
+								arg: { type: "variable-reference", name: "duration" },
+								annotation: {
+									type: "function-reference",
+									name: "relativetime",
+									options: [
+										{
+											name: "unit",
+											value: { type: "variable-reference", name: "unit" },
+										},
+										{
+											name: "style",
+											value: { type: "literal", value: "short" },
+										},
+									],
+								},
+							},
+						},
+					],
+					messages: [
+						{
+							locale: "en",
+							variants: [
+								{
+									pattern: [
+										{
+											type: "expression",
+											arg: {
+												type: "variable-reference",
+												name: "formattedDuration",
+											},
+										},
+									],
+								},
+							],
+						},
+					],
+				})
+			);
+
+			const output = await compileProject({
+				project: projectWithRelativeTimeOptions,
+				compilerOptions,
+			});
+
+			const tsProject = await typescriptProject({
+				useInMemoryFileSystem: true,
+				compilerOptions: superStrictRuleOutAnyErrorTsSettings,
+			});
+
+			for (const [fileName, code] of Object.entries(output)) {
+				if (fileName.endsWith(".js") || fileName.endsWith(".ts")) {
+					tsProject.createSourceFile(fileName, code);
+				}
+			}
+
+			const program = tsProject.createProgram();
+			const diagnostics = ts.getPreEmitDiagnostics(program).filter((d) => {
+				return !d.messageText
+					.toString()
+					.includes("Cannot find module 'async_hooks'");
+			});
+
+			for (const diagnostic of diagnostics) {
+				console.error(diagnostic.messageText, diagnostic.file?.fileName);
+			}
+			expect(diagnostics.length).toEqual(0);
+		});
 	}
 );
 
@@ -1238,6 +1386,18 @@ async function importCode(code: string) {
 	return await import(
 		`data:application/javascript;base64,${Buffer.from(codeWithComment, "utf8").toString("base64")}`
 	);
+}
+
+function expectedRelativeTimeMessage(
+	locale: string,
+	duration: number,
+	unit: string,
+	options: Intl.RelativeTimeFormatOptions = {}
+) {
+	return `Updated ${new Intl.RelativeTimeFormat(locale, options).format(
+		duration,
+		unit as Intl.RelativeTimeFormatUnit
+	)}.`;
 }
 
 const project = await loadProjectInMemory({
@@ -1408,6 +1568,139 @@ const mockBundles: BundleNested[] = [
 			},
 		],
 	},
+	createBundleNested({
+		id: "relative_time_literal",
+		declarations: [
+			{
+				type: "input-variable",
+				name: "duration",
+			},
+			{
+				type: "local-variable",
+				name: "formattedDuration",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "duration" },
+					annotation: {
+						type: "function-reference",
+						name: "relativetime",
+						options: [
+							{ name: "unit", value: { type: "literal", value: "day" } },
+							{ name: "numeric", value: { type: "literal", value: "auto" } },
+						],
+					},
+				},
+			},
+		],
+		messages: [
+			{
+				locale: "en",
+				variants: [
+					{
+						pattern: [
+							{ type: "text", value: "Updated " },
+							{
+								type: "expression",
+								arg: {
+									type: "variable-reference",
+									name: "formattedDuration",
+								},
+							},
+							{ type: "text", value: "." },
+						],
+					},
+				],
+			},
+			{
+				locale: "de",
+				variants: [
+					{
+						pattern: [
+							{ type: "text", value: "Updated " },
+							{
+								type: "expression",
+								arg: {
+									type: "variable-reference",
+									name: "formattedDuration",
+								},
+							},
+							{ type: "text", value: "." },
+						],
+					},
+				],
+			},
+		],
+	}),
+	createBundleNested({
+		id: "relative_time_dynamic",
+		declarations: [
+			{
+				type: "input-variable",
+				name: "duration",
+			},
+			{
+				type: "input-variable",
+				name: "unit",
+			},
+			{
+				type: "local-variable",
+				name: "formattedDuration",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "duration" },
+					annotation: {
+						type: "function-reference",
+						name: "relativetime",
+						options: [
+							{
+								name: "unit",
+								value: { type: "variable-reference", name: "unit" },
+							},
+							{ name: "style", value: { type: "literal", value: "short" } },
+						],
+					},
+				},
+			},
+		],
+		messages: [
+			{
+				locale: "en",
+				variants: [
+					{
+						pattern: [
+							{ type: "text", value: "Updated " },
+							{
+								type: "expression",
+								arg: {
+									type: "variable-reference",
+									name: "formattedDuration",
+								},
+							},
+							{ type: "text", value: "." },
+						],
+					},
+				],
+			},
+			{
+				locale: "de",
+				variants: [
+					{
+						pattern: [
+							{ type: "text", value: "Updated " },
+							{
+								type: "expression",
+								arg: {
+									type: "variable-reference",
+									name: "formattedDuration",
+								},
+							},
+							{ type: "text", value: "." },
+						],
+					},
+				],
+			},
+		],
+	}),
 	{
 		id: "auth_password_error",
 		declarations: [

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -233,6 +233,39 @@ test("emitTsDeclarations generates declaration files", async () => {
 	expect(output["messages/_index.d.ts"]).toContain("relative_time_dynamic");
 	expect(output["registry.d.ts"]).toContain("RelativeTimeFormatUnit");
 	expect(output["registry.d.ts"]).toContain("relativetime");
+
+	const tsProject = await typescriptProject({
+		useInMemoryFileSystem: true,
+		compilerOptions: {
+			module: ts.ModuleKind.Node16,
+			moduleResolution: ts.ModuleResolutionKind.Node16,
+			strict: true,
+		},
+	});
+
+	for (const [fileName, code] of Object.entries(output)) {
+		if (fileName.endsWith(".d.ts")) {
+			tsProject.createSourceFile(fileName, code);
+		}
+	}
+
+	tsProject.createSourceFile(
+		"test.ts",
+		`
+			import { relative_time_dynamic } from "./messages.js";
+			import { relativetime } from "./registry.js";
+
+			relative_time_dynamic({ duration: -3, unit: "hour" }) satisfies string;
+			relativetime("en", -3, { unit: "hour", style: "short" }) satisfies string;
+		`
+	);
+
+	const program = tsProject.createProgram();
+	const diagnostics = ts.getPreEmitDiagnostics(program);
+	for (const diagnostic of diagnostics) {
+		console.error(diagnostic.messageText, diagnostic.file?.fileName);
+	}
+	expect(diagnostics.length).toEqual(0);
 });
 
 test("handles message bundles with a : in the id", async () => {

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -916,12 +916,17 @@ describe.each([
 		});
 
 		test("relativetime dynamic unit casts generated options without narrowing public inputs", () => {
-			const generatedOutput = Object.values(output).join("\n");
+			const relativeTimeDynamicFile =
+				compilerOptions.outputStructure === "locale-modules"
+					? "messages/en.js"
+					: "messages/relative_time_dynamic.js";
+			const relativeTimeDynamicModule = output[relativeTimeDynamicFile]!;
 
-			expect(generatedOutput).toContain(
+			expect(output).toHaveProperty(relativeTimeDynamicFile);
+			expect(relativeTimeDynamicModule).toContain(
 				'unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit)'
 			);
-			expect(generatedOutput).toContain(
+			expect(relativeTimeDynamicModule).toContain(
 				"{ duration: NonNullable<unknown>, unit: NonNullable<unknown> }"
 			);
 		});

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -700,13 +700,11 @@ describe.each([
 
 				runtime.setLocale("de");
 				expect(m.relative_time_literal({ duration: -1 })).toBe(
-					expectedRelativeTimeMessage("de", -1, "day", { numeric: "auto" })
+					"Updated gestern."
 				);
 				expect(
 					m.relative_time_literal({ duration: -1 }, { locale: "en" })
-				).toBe(
-					expectedRelativeTimeMessage("en", -1, "day", { numeric: "auto" })
-				);
+				).toBe("Updated yesterday.");
 			});
 
 			test("relativetime formatter works with dynamic units", async () => {
@@ -714,16 +712,12 @@ describe.each([
 
 				runtime.setLocale("en");
 				expect(m.relative_time_dynamic({ duration: -3, unit: "hour" })).toBe(
-					expectedRelativeTimeMessage("en", -3, "hour", {
-						style: "short",
-					})
+					"Updated 3 hr. ago."
 				);
 
 				runtime.setLocale("de");
 				expect(m.relative_time_dynamic({ duration: 2, unit: "weeks" })).toBe(
-					expectedRelativeTimeMessage("de", 2, "weeks", {
-						style: "short",
-					})
+					"Updated in 2 Wochen."
 				);
 			});
 
@@ -1419,18 +1413,6 @@ async function importCode(code: string) {
 	return await import(
 		`data:application/javascript;base64,${Buffer.from(codeWithComment, "utf8").toString("base64")}`
 	);
-}
-
-function expectedRelativeTimeMessage(
-	locale: string,
-	duration: number,
-	unit: string,
-	options: Intl.RelativeTimeFormatOptions = {}
-) {
-	return `Updated ${new Intl.RelativeTimeFormat(locale, options).format(
-		duration,
-		unit as Intl.RelativeTimeFormatUnit
-	)}.`;
 }
 
 const project = await loadProjectInMemory({

--- a/src/compiler/create-readme.ts
+++ b/src/compiler/create-readme.ts
@@ -38,7 +38,7 @@ paraglide/
 ├── messages.js      # Message exports (import this)
 ├── messages/        # Individual message functions
 ├── runtime.js       # Locale detection & configuration
-├── registry.js      # Formatting utilities (plural, number, datetime)
+├── registry.js      # Formatting utilities (plural, number, datetime, relativetime)
 ├── server.js        # Server-side middleware
 └── .gitignore       # Marks folder as generated
 \`\`\`

--- a/src/compiler/registry.ts
+++ b/src/compiler/registry.ts
@@ -14,6 +14,10 @@
 export function createRegistry(): string {
 	return `
 /**
+ * @typedef {"year" | "years" | "quarter" | "quarters" | "month" | "months" | "week" | "weeks" | "day" | "days" | "hour" | "hours" | "minute" | "minutes" | "second" | "seconds"} RelativeTimeFormatUnit
+ */
+
+/**
  * @param {import("./runtime.js").Locale} locale
  * @param {unknown} input
  * @param {Intl.PluralRulesOptions} [options]
@@ -41,5 +45,16 @@ export function number(locale, input, options) {
  */
 export function datetime(locale, input, options) {
 	return new Intl.DateTimeFormat(locale, options).format(new Date(/** @type {string} */ (input)))
+};
+
+/**
+ * @param {import("./runtime.js").Locale} locale
+ * @param {unknown} input
+ * @param {Intl.RelativeTimeFormatOptions & { unit: RelativeTimeFormatUnit }} options
+ * @returns {string}
+ */
+export function relativetime(locale, input, options) {
+	const { unit, ...intlOptions } = options;
+	return new Intl.RelativeTimeFormat(locale, intlOptions).format(Number(input), unit);
 };`;
 }


### PR DESCRIPTION
Adds a `relativetime` declaration formatter backed by `Intl.RelativeTimeFormat`, with support for literal and dynamic units like `unit=day` and `unit=$unit`.

Includes compiler, generated type, example, and docs coverage.

## Proposed API

Message declarations:

```json
{
  "last_seen": [{
    "declarations": [
      "input duration",
      "local formattedDuration = duration: relativetime unit=day numeric=auto"
    ],
    "match": {
      "duration=*": "Last seen {formattedDuration}."
    }
  }],
  "relative_update": [{
    "declarations": [
      "input duration",
      "input unit",
      "local formattedDuration = duration: relativetime unit=$unit style=short"
    ],
    "match": {
      "duration=*,unit=*": "Updated {formattedDuration}."
    }
  }]
}
```

User code:

```ts
import { m } from "./paraglide/messages.js";

m.last_seen({ duration: -1 }); // "Last seen yesterday."
m.relative_update({ duration: -3, unit: "hour" }); // "Updated 3 hr. ago."
```

Generated message code follows the existing registry-helper pattern:

```js
const formattedDuration = registry.relativetime("en", i?.duration, {
  unit: "day",
  numeric: "auto"
});

const formattedDuration = registry.relativetime("en", i?.duration, {
  unit: /** @type {import("../registry.js").RelativeTimeFormatUnit} */ (i?.unit),
  style: "short"
});
```

`unit` is required by Paraglide and is stripped before constructing `Intl.RelativeTimeFormat`, matching the native `format(value, unit)` call shape.

## AI disclosure

This PR was developed with Codex GPT-5.5. I have reviewed the changes and am dogfooding this fork in my product.
