### PR TITLE
Mark TypeScript as optional peer for declaration emit

### DIFF
--- a/.changeset/calm-pianos-search.md
+++ b/.changeset/calm-pianos-search.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Mark `typescript` as an optional peer dependency and show a clear error when `emitTsDeclarations` is enabled without TypeScript installed.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,14 @@
 		"unplugin": "^2.1.2",
 		"urlpattern-polyfill": "^10.0.0"
 	},
+	"peerDependencies": {
+		"typescript": ">=5"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@changesets/cli": "^2.29.7",
 		"@inlang/plugin-message-format": "^4.3.0",

--- a/src/compiler/emit-ts-declarations.ts
+++ b/src/compiler/emit-ts-declarations.ts
@@ -6,6 +6,10 @@ const missingTypeScriptMessage = `Paraglide's "emitTsDeclarations" option requir
 
 Install TypeScript in your project, or disable "emitTsDeclarations".`;
 
+const failedToLoadTypeScriptMessage = `Paraglide's "emitTsDeclarations" option requires the "typescript" package.
+
+TypeScript appears to be installed, but failed to load. See the error cause for details.`;
+
 /**
  * Generates `.d.ts` files for the compiled Paraglide output using the TypeScript compiler.
  *
@@ -149,7 +153,20 @@ export async function emitTsDeclarations(
 async function importTypeScript(): Promise<TypeScript> {
 	try {
 		return await import("typescript");
-	} catch {
-		throw new Error(missingTypeScriptMessage);
+	} catch (cause) {
+		if (isMissingTypeScriptPackageError(cause)) {
+			throw new Error(missingTypeScriptMessage);
+		}
+		throw new Error(failedToLoadTypeScriptMessage, { cause });
 	}
+}
+
+function isMissingTypeScriptPackageError(cause: unknown): boolean {
+	if (cause instanceof Error === false) {
+		return false;
+	}
+	if ("code" in cause && cause.code !== "ERR_MODULE_NOT_FOUND") {
+		return false;
+	}
+	return cause.message.includes("Cannot find package 'typescript'");
 }

--- a/src/compiler/emit-ts-declarations.ts
+++ b/src/compiler/emit-ts-declarations.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 
 type TypeScript = typeof import("typescript");
 
+const missingTypeScriptMessage = `Paraglide's "emitTsDeclarations" option requires the "typescript" package.
+
+Install TypeScript in your project, or disable "emitTsDeclarations".`;
+
 /**
  * Generates `.d.ts` files for the compiled Paraglide output using the TypeScript compiler.
  *
@@ -15,7 +19,7 @@ type TypeScript = typeof import("typescript");
 export async function emitTsDeclarations(
 	output: Record<string, string>
 ): Promise<Record<string, string>> {
-	const ts: TypeScript = await import("typescript");
+	const ts = await importTypeScript();
 
 	const jsEntries = Object.entries(output).filter(([fileName]) =>
 		fileName.endsWith(".js")
@@ -140,4 +144,12 @@ export async function emitTsDeclarations(
 	program.emit(undefined, undefined, undefined, true);
 
 	return declarations;
+}
+
+async function importTypeScript(): Promise<TypeScript> {
+	try {
+		return await import("typescript");
+	} catch {
+		throw new Error(missingTypeScriptMessage);
+	}
 }


### PR DESCRIPTION
## Summary

- Mark `typescript` as an optional peer dependency of `@inlang/paraglide-js`.
- Replace the raw dynamic import failure in `emitTsDeclarations` with a clear error explaining that TypeScript is only required for that option.
- Add a patch changeset for the package metadata and error-message fix.

## Root Cause

`emitTsDeclarations` dynamically imports `typescript`, but the package manifest only listed TypeScript as a dev dependency. Under pnpm's isolated dependency layout, consumers enabling `emitTsDeclarations` without a project-level TypeScript install saw an `ERR_MODULE_NOT_FOUND` from the published artifact instead of a useful feature-specific message.

Closes https://github.com/opral/paraglide-js/issues/673

## Validation

- `pnpm exec vitest run src/compiler/compile-project.test.ts`
- `pnpm exec tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dependency-metadata and error-handling change; behavior only differs when `emitTsDeclarations` is enabled or TypeScript fails to load.
> 
> **Overview**
> `@inlang/paraglide-js` now declares `typescript` as an *optional* `peerDependency`, aligning install expectations with the fact it’s only needed for declaration generation.
> 
> `emitTsDeclarations` no longer fails with a raw dynamic import error; it detects a missing `typescript` package and throws a clear, actionable message (and wraps other load failures with context). A patch changeset is included to release the metadata + error-message improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e05d8ce2dca80d572486d97cc57a9811ac3eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->