### PR TITLE
[codex] Pin jsDelivr plugin defaults

### DIFF
--- a/.changeset/pin-jsdelivr-plugin-defaults.md
+++ b/.changeset/pin-jsdelivr-plugin-defaults.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Pin default jsDelivr plugin URLs to exact versions in generated project settings.

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -88,7 +88,7 @@ Add the plugin URL to the `modules` array in your `project.inlang/settings.json`
   "baseLocale": "en",
   "locales": ["en", "de"],
   "modules": [
--    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js"
+-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js"
 +    "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.0.11/dist/index.js"
   ]
 }
@@ -103,7 +103,7 @@ You can use multiple plugins to support different file formats in the same proje
 	"baseLocale": "en",
 	"locales": ["en", "de"],
 	"modules": [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.0.11/dist/index.js"
 	]
 }

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -88,8 +88,8 @@ Add the plugin URL to the `modules` array in your `project.inlang/settings.json`
   "baseLocale": "en",
   "locales": ["en", "de"],
   "modules": [
--    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
-+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@latest/dist/index.js"
+-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js"
++    "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.0.11/dist/index.js"
   ]
 }
 ```
@@ -103,8 +103,8 @@ You can use multiple plugins to support different file formats in the same proje
 	"baseLocale": "en",
 	"locales": ["en", "de"],
 	"modules": [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@latest/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.0.11/dist/index.js"
 	]
 }
 ```

--- a/examples/astro/project.inlang/settings.json
+++ b/examples/astro/project.inlang/settings.json
@@ -8,8 +8,8 @@
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.6/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
 		"pathPattern": "./messages/{languageTag}.json"

--- a/examples/astro/project.inlang/settings.json
+++ b/examples/astro/project.inlang/settings.json
@@ -8,8 +8,8 @@
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
 		"https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-valid-js-identifier@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
 		"pathPattern": "./messages/{languageTag}.json"

--- a/examples/incremental-migration/README.md
+++ b/examples/incremental-migration/README.md
@@ -41,7 +41,7 @@ Paraglide uses [inlang plugins](https://inlang.com/c/plugins) to read translatio
   "locales": ["en", "de", "fr"],
   "modules": [
 -    "https://cdn.jsdelivr.net/npm/@inlang/message-format-plugin@latest/dist/index.js"
-+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@latest/dist/index.js"
++    "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.0.11/dist/index.js"
   ],
 +  "plugin.inlang.i18next": {
 +    "pathPattern": "./locales/{locale}.json"

--- a/examples/react-router/project.inlang/settings.json
+++ b/examples/react-router/project.inlang/settings.json
@@ -3,8 +3,8 @@
 	"baseLocale": "en",
 	"locales": ["en", "de"],
 	"modules": [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.6/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
 		"pathPattern": "./messages/{locale}.json"

--- a/examples/react-router/project.inlang/settings.json
+++ b/examples/react-router/project.inlang/settings.json
@@ -3,8 +3,8 @@
 	"baseLocale": "en",
 	"locales": ["en", "de"],
 	"modules": [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
 		"pathPattern": "./messages/{locale}.json"

--- a/examples/sveltekit/project.inlang/settings.json
+++ b/examples/sveltekit/project.inlang/settings.json
@@ -3,8 +3,8 @@
 	"baseLocale": "en",
 	"locales": ["en", "de"],
 	"modules": [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.6/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
 		"pathPattern": "./messages/{locale}.json"

--- a/examples/sveltekit/project.inlang/settings.json
+++ b/examples/sveltekit/project.inlang/settings.json
@@ -3,8 +3,8 @@
 	"baseLocale": "en",
 	"locales": ["en", "de"],
 	"modules": [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
 	],
 	"plugin.inlang.messageFormat": {
 		"pathPattern": "./messages/{locale}.json"

--- a/examples/tanstack-start/project.inlang/settings.json
+++ b/examples/tanstack-start/project.inlang/settings.json
@@ -3,8 +3,8 @@
   "baseLocale": "en",
   "locales": ["en", "de"],
   "modules": [
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js",
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
   ],
   "plugin.inlang.messageFormat": {
     "pathPattern": "./messages/{locale}.json"

--- a/examples/tanstack-start/project.inlang/settings.json
+++ b/examples/tanstack-start/project.inlang/settings.json
@@ -3,8 +3,8 @@
   "baseLocale": "en",
   "locales": ["en", "de"],
   "modules": [
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.6/dist/index.js"
   ],
   "plugin.inlang.messageFormat": {
     "pathPattern": "./messages/{locale}.json"

--- a/src/cli/defaults.ts
+++ b/src/cli/defaults.ts
@@ -9,8 +9,8 @@ const defaultProjectSettings = {
 	baseLocale: "en",
 	locales: ["en", "de"],
 	modules: [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js",
 	],
 	"plugin.inlang.messageFormat": {
 		pathPattern: "./messages/{locale}.json",

--- a/src/cli/defaults.ts
+++ b/src/cli/defaults.ts
@@ -9,8 +9,8 @@ const defaultProjectSettings = {
 	baseLocale: "en",
 	locales: ["en", "de"],
 	modules: [
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.3.0/dist/index.js",
-		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.6/dist/index.js",
 	],
 	"plugin.inlang.messageFormat": {
 		pathPattern: "./messages/{locale}.json",

--- a/src/cli/steps/maybe-add-sherlock.ts
+++ b/src/cli/steps/maybe-add-sherlock.ts
@@ -44,7 +44,7 @@ export const maybeAddSherlock: CliStep<
 	) {
 		// add the m function matcher plugin
 		settings.modules.push(
-			"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js"
+			"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
 		);
 		await ctx.project.settings.set(settings);
 	}

--- a/src/cli/steps/maybe-add-sherlock.ts
+++ b/src/cli/steps/maybe-add-sherlock.ts
@@ -44,7 +44,7 @@ export const maybeAddSherlock: CliStep<
 	) {
 		// add the m function matcher plugin
 		settings.modules.push(
-			"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.1.0/dist/index.js"
+			"https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.6/dist/index.js"
 		);
 		await ctx.project.settings.set(settings);
 	}


### PR DESCRIPTION
## Summary

Pin Paraglide's default jsDelivr plugin URLs to exact versions instead of mutable major or latest aliases.

## Changes

- Pin generated `project.inlang/settings.json` defaults to `@inlang/plugin-message-format@4.4.0` and `@inlang/plugin-m-function-matcher@2.2.6`.
- Pin the Sherlock helper path that adds the m-function matcher plugin.
- Update copyable examples and file-format docs so they no longer recommend `@latest` for these plugin URLs.
- Add a patch changeset for `@inlang/paraglide-js`.

## Why

This keeps Paraglide's portable jsDelivr-based project files while avoiding automatic build-time upgrades through major-version or `latest` CDN aliases. It reduces surprise build changes and keeps plugin upgrades more intentional.

## Validation

- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to pinning CDN module URLs in CLI-generated defaults and documentation/examples, reducing surprise upgrades without altering core compilation logic.
> 
> **Overview**
> **Pins jsDelivr plugin defaults to exact versions** instead of `@latest`/major aliases when generating `project.inlang/settings.json` (notably `@inlang/plugin-message-format@4.4.0` and `@inlang/plugin-m-function-matcher@2.2.6`).
> 
> Updates the Sherlock setup step to add the pinned matcher URL, and refreshes docs/examples to recommend the versioned URLs. Adds a patch changeset for `@inlang/paraglide-js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a062f30caab3bbd542a15510dfde4ade0fd3a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->