### PR TITLE
Fix Infinity input literal matches

### DIFF
--- a/.changeset/fix-infinity-input-matches.md
+++ b/.changeset/fix-infinity-input-matches.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix input match generation so `Infinity` selectors match both numeric `Infinity` values and string `"Infinity"` values.

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -215,6 +215,103 @@ test("numeric literal matches accept number and string inputs without loose coer
 	expect(numeric_select_message({ input: true })).toBe("Fallback");
 });
 
+// https://github.com/opral/paraglide-js/issues/682
+test("infinity input matches accept number and string inputs", async () => {
+	const declarations: Declaration[] = [
+		{ type: "input-variable", name: "capacity" },
+		{ type: "input-variable", name: "pending" },
+		{ type: "input-variable", name: "count" },
+	];
+	const message: Message = {
+		locale: "en",
+		id: "group-member-count-id",
+		bundleId: "group_member_count",
+		selectors: [
+			{ type: "variable-reference", name: "capacity" },
+			{ type: "variable-reference", name: "pending" },
+		],
+	};
+	const variants: Variant[] = [
+		{
+			id: "1",
+			messageId: "group-member-count-id",
+			matches: [
+				{ type: "literal-match", key: "capacity", value: "Infinity" },
+				{ type: "catchall-match", key: "pending" },
+			],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+				},
+			],
+		},
+		{
+			id: "2",
+			messageId: "group-member-count-id",
+			matches: [
+				{ type: "catchall-match", key: "capacity" },
+				{ type: "literal-match", key: "pending", value: "0" },
+			],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+				},
+				{ type: "text", value: " / " },
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "capacity" },
+				},
+			],
+		},
+		{
+			id: "3",
+			messageId: "group-member-count-id",
+			matches: [
+				{ type: "catchall-match", key: "capacity" },
+				{ type: "catchall-match", key: "pending" },
+			],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+				},
+				{ type: "text", value: " / " },
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "capacity" },
+				},
+				{ type: "text", value: " (" },
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "pending" },
+				},
+				{ type: "text", value: " pending)" },
+			],
+		},
+	];
+
+	const compiled = compileMessage(declarations, message, variants);
+	const { group_member_count } = await import(
+		"data:text/javascript;base64," +
+			btoa("export const group_member_count = " + compiled.code)
+	);
+
+	expect(group_member_count({ capacity: Infinity, pending: 5, count: 5 })).toBe(
+		"5"
+	);
+	expect(
+		group_member_count({ capacity: "Infinity", pending: 5, count: 5 })
+	).toBe("5");
+	expect(group_member_count({ capacity: 10, pending: 0, count: 5 })).toBe(
+		"5 / 10"
+	);
+	expect(group_member_count({ capacity: 10, pending: 5, count: 5 })).toBe(
+		"5 / 10 (5 pending)"
+	);
+});
+
 // https://github.com/opral/paraglide-js/issues/571
 test("compiles a message that can be parsed as JSON", async () => {
 	const declarations: Declaration[] = [];

--- a/src/compiler/jsdoc-types.test.ts
+++ b/src/compiler/jsdoc-types.test.ts
@@ -101,6 +101,24 @@ test("inputsType accepts both number and string forms for numeric match values",
 	expect(result).toBe('{ input: 1 | "1" | 2 | "2" }');
 });
 
+test("inputsType widens infinity match values to number and string forms", () => {
+	const inputs: InputVariable[] = [{ name: "input", type: "input-variable" }];
+
+	const matchTypes = new Map([
+		[
+			"input",
+			{
+				literals: new Set(["Infinity", "-Infinity"]),
+				hasCatchAll: false,
+			},
+		],
+	]);
+
+	const result = inputsType(inputs, matchTypes);
+
+	expect(result).toBe('{ input: number | "-Infinity" | "Infinity" }');
+});
+
 test("inputsType falls back to NonNullable<unknown> when catchall exists", () => {
 	const inputs: InputVariable[] = [{ name: "type", type: "input-variable" }];
 

--- a/src/compiler/match-literals.ts
+++ b/src/compiler/match-literals.ts
@@ -1,4 +1,5 @@
-const UNSUPPORTED_NUMERIC_MATCH_PREFIX = /^(0[bBoOxX]|[+-]?Infinity$|NaN$)/;
+const UNSUPPORTED_NUMERIC_MATCH_PREFIX = /^(0[bBoOxX]|NaN$)/;
+const INFINITY_MATCH_LITERAL = /^[+]?Infinity$/;
 
 export function renderInputMatchCondition(
 	inputExpression: string,
@@ -20,7 +21,11 @@ export function renderInputMatchTypeVariants(literalValue: string): string[] {
 	const variants = new Set<string>();
 
 	if (numericLiteral !== undefined) {
-		variants.add(numericLiteral);
+		variants.add(
+			numericLiteral === "Infinity" || numericLiteral === "-Infinity"
+				? "number"
+				: numericLiteral
+		);
 	}
 
 	variants.add(JSON.stringify(literalValue));
@@ -35,6 +40,14 @@ function parseNumericMatchLiteral(literalValue: string): string | undefined {
 		UNSUPPORTED_NUMERIC_MATCH_PREFIX.test(literalValue)
 	) {
 		return undefined;
+	}
+
+	if (INFINITY_MATCH_LITERAL.test(literalValue)) {
+		return "Infinity";
+	}
+
+	if (literalValue === "-Infinity") {
+		return "-Infinity";
 	}
 
 	const parsed = Number(literalValue);


### PR DESCRIPTION
Summary
- restore compatibility for `Infinity` input match literals without broad loose equality
- add regression coverage for issue #682 and generated input typing
- add a patch changeset

Tests
- `pnpm run build`
- `pnpm run test`

closes https://github.com/opral/paraglide-js/issues/682

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches message variant matching and generated input typings; a small regex/parsing change could affect how numeric literal selectors are interpreted at runtime.
> 
> **Overview**
> Fixes input literal matching for `Infinity`/`-Infinity` by parsing these literals explicitly and generating match conditions that accept both the numeric value and its string form.
> 
> Updates generated JSDoc input types so `Infinity` literals widen to `number` (while still including the string literal), and adds regression tests covering the runtime selection behavior and the typing output. Includes a patch changeset for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb7d027701c58b708d8fa4c570a93aebd8b38d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->