### PR TITLE
Allow optional ParaglideMessage inputs

### DIFF
--- a/.changeset/quiet-apples-drop.md
+++ b/.changeset/quiet-apples-drop.md
@@ -1,0 +1,8 @@
+---
+"@inlang/paraglide-js-react": patch
+"@inlang/paraglide-js-solid": patch
+"@inlang/paraglide-js-svelte": patch
+"@inlang/paraglide-js-vue": patch
+---
+
+Allow `ParaglideMessage` inputs to be omitted for messages without parameters.

--- a/framework/react/src/message.test.tsx
+++ b/framework/react/src/message.test.tsx
@@ -16,7 +16,6 @@ test("renders compiled markup and exposes options/attributes as records", () => 
 	const html = renderToStaticMarkup(
 		<ParaglideMessage
 			message={m.cta}
-			inputs={{}}
 			markup={{
 				link: ({ children, options, attributes }) => (
 					<a
@@ -37,7 +36,6 @@ test("renders compiled nested markup", () => {
 	const html = renderToStaticMarkup(
 		<ParaglideMessage
 			message={m.nested_cta}
-			inputs={{}}
 			markup={{
 				link: ({ children, options }) => <a href={options.to}>{children}</a>,
 				strong: ({ children }) => <strong>{children}</strong>,
@@ -51,9 +49,19 @@ test("renders compiled nested markup", () => {
 test("enforces markup props at type level", () => {
 	if (false) {
 		// @ts-expect-error markup renderers are required for markup messages
-		ParaglideMessage<typeof m.cta>({ message: m.cta, inputs: {} });
-		// @ts-expect-error plain messages do not accept a markup prop
-		ParaglideMessage<typeof m.hello>({ message: m.hello, inputs: { name: "Ada" }, markup: { link: () => null } });
+		ParaglideMessage<typeof m.cta>({ message: m.cta });
+		ParaglideMessage<typeof m.cta>({
+			message: m.cta,
+			markup: { link: () => null },
+		});
+		// @ts-expect-error inputs are required for messages with parameters
+		ParaglideMessage<typeof m.hello>({ message: m.hello });
+			ParaglideMessage<typeof m.hello>({
+				message: m.hello,
+				inputs: { name: "Ada" },
+				// @ts-expect-error plain messages do not accept a markup prop
+				markup: { link: () => null },
+			});
 	}
 
 	expect(true).toBe(true);

--- a/framework/react/src/message.tsx
+++ b/framework/react/src/message.tsx
@@ -16,19 +16,12 @@ export type MessageLike<
 	TInputs = Record<string, never>,
 	TOptions extends MessageOptions = MessageOptions,
 	TMarkup extends MessageMarkupSchema = MessageMarkupSchema,
-> = ((
-	inputs: TInputs,
-	options?: TOptions
-) => string) & {
+> = ((inputs: TInputs, options?: TOptions) => string) & {
 	parts?: (inputs: TInputs, options?: TOptions) => MessagePart[];
 } & MessageMetadata<TInputs, TOptions, TMarkup>;
 
 type MessageMetadataOf<TMessage extends MessageLike<any, any, any>> =
-	TMessage extends MessageMetadata<
-		infer TInputs,
-		infer TOptions,
-		infer TMarkup
-	>
+	TMessage extends MessageMetadata<infer TInputs, infer TOptions, infer TMarkup>
 		? {
 				inputs: TInputs;
 				options: TOptions;
@@ -54,11 +47,12 @@ type NormalizeOptions<TOptions> = [TOptions] extends [undefined]
 		? NonNullable<TOptions>
 		: MessageOptions;
 
-type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> = NormalizeOptions<
-	MessageMetadataOf<TMessage> extends { options: infer TOptions }
-		? TOptions
-		: SignatureOptions<TMessage>
->;
+type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> =
+	NormalizeOptions<
+		MessageMetadataOf<TMessage> extends { options: infer TOptions }
+			? TOptions
+			: SignatureOptions<TMessage>
+	>;
 
 type MessageMarkup<TMessage extends MessageLike<any, any, any>> =
 	MessageMetadataOf<TMessage> extends { markup: infer TMarkup }
@@ -88,9 +82,7 @@ export type MarkupRenderer<
 	TOptions extends MessageOptions = MessageOptions,
 	TTag extends MessageMarkupTag = MessageMarkupTag,
 	TName extends string = string,
-> = (
-	props: MarkupRendererProps<TInputs, TOptions, TTag, TName>
-) => ReactNode;
+> = (props: MarkupRendererProps<TInputs, TOptions, TTag, TName>) => ReactNode;
 
 type MarkupRenderersForSchema<
 	TInputs,
@@ -114,11 +106,14 @@ type AnyMarkupRenderer = MarkupRenderer<
 
 type AnyMarkupRenderers = Partial<Record<string, AnyMarkupRenderer>>;
 
+type MessageInputsProp<TInputs> = keyof TInputs extends never
+	? { inputs?: TInputs }
+	: { inputs: TInputs };
+
 type MessageBaseProps<TMessage extends MessageLike<any, any, any>> = {
 	message: TMessage;
-	inputs: MessageInputs<TMessage>;
 	options?: MessageRuntimeOptions<TMessage>;
-};
+} & MessageInputsProp<MessageInputs<TMessage>>;
 
 type MessageMarkupProps<TMessage extends MessageLike<any, any, any>> =
 	keyof MessageMarkup<TMessage> extends never
@@ -149,10 +144,13 @@ type OpenMarkupFrame = {
  * Uses `message.parts()` when available and falls back to `message()` for plain
  * messages without markup.
  */
-export function ParaglideMessage<
-	TMessage extends MessageLike<any, any, any>,
->(props: MessageProps<NoInfer<TMessage>> & { message: TMessage }): ReactNode {
-	const { message, inputs, options: messageOptions } = props;
+export function ParaglideMessage<TMessage extends MessageLike<any, any, any>>(
+	props: MessageProps<NoInfer<TMessage>> & { message: TMessage }
+): ReactNode {
+	const { message, options: messageOptions } = props;
+	const inputs =
+		(props as { inputs?: MessageInputs<TMessage> }).inputs ??
+		({} as MessageInputs<TMessage>);
 	const markup = (props as { markup?: AnyMarkupRenderers }).markup;
 	const callableMessage = message as MessageLike<
 		MessageInputs<TMessage>,
@@ -253,17 +251,18 @@ function renderParts<TInputs, TOptions extends MessageOptions = MessageOptions>(
 	return rootChildren;
 }
 
-function renderMarkup<TInputs, TOptions extends MessageOptions = MessageOptions>(
-	args: {
-		name: string;
-		children: ReactNode[];
-		options: MessageMarkupOptions;
-		attributes: MessageMarkupAttributes;
-		inputs: TInputs;
-		messageOptions?: TOptions;
-		markup?: AnyMarkupRenderers;
-	}
-): ReactNode {
+function renderMarkup<
+	TInputs,
+	TOptions extends MessageOptions = MessageOptions,
+>(args: {
+	name: string;
+	children: ReactNode[];
+	options: MessageMarkupOptions;
+	attributes: MessageMarkupAttributes;
+	inputs: TInputs;
+	messageOptions?: TOptions;
+	markup?: AnyMarkupRenderers;
+}): ReactNode {
 	const renderer = args.markup?.[args.name];
 	const children = toChildren(args.children);
 

--- a/framework/solid/src/message.test.ts
+++ b/framework/solid/src/message.test.ts
@@ -12,7 +12,6 @@ test("renders compiled plain messages when parts() is not present", () => {
 test("renders compiled markup and exposes options/attributes as records", () => {
 	const html = ParaglideMessage({
 		message: m.cta,
-		inputs: {},
 		markup: {
 			link: ({ children, options, attributes }) =>
 				`<a href="${options.to}" data-track="${attributes.track === true ? "true" : "false"}">${children ?? ""}</a>`,
@@ -25,9 +24,9 @@ test("renders compiled markup and exposes options/attributes as records", () => 
 test("renders compiled nested markup", () => {
 	const html = ParaglideMessage({
 		message: m.nested_cta,
-		inputs: {},
 		markup: {
-			link: ({ children, options }) => `<a href="${options.to}">${children ?? ""}</a>`,
+			link: ({ children, options }) =>
+				`<a href="${options.to}">${children ?? ""}</a>`,
 			strong: ({ children }) => `<strong>${children ?? ""}</strong>`,
 		},
 	});
@@ -38,9 +37,19 @@ test("renders compiled nested markup", () => {
 test("enforces markup props at type level", () => {
 	if (false) {
 		// @ts-expect-error markup renderers are required for markup messages
-		ParaglideMessage<typeof m.cta>({ message: m.cta, inputs: {} });
-		// @ts-expect-error plain messages do not accept a markup prop
-		ParaglideMessage<typeof m.hello>({ message: m.hello, inputs: { name: "Ada" }, markup: { link: () => "ignored" } });
+		ParaglideMessage<typeof m.cta>({ message: m.cta });
+		ParaglideMessage<typeof m.cta>({
+			message: m.cta,
+			markup: { link: () => "ignored" },
+		});
+		// @ts-expect-error inputs are required for messages with parameters
+		ParaglideMessage<typeof m.hello>({ message: m.hello });
+			ParaglideMessage<typeof m.hello>({
+				message: m.hello,
+				inputs: { name: "Ada" },
+				// @ts-expect-error plain messages do not accept a markup prop
+				markup: { link: () => "ignored" },
+			});
 	}
 
 	expect(true).toBe(true);

--- a/framework/solid/src/message.ts
+++ b/framework/solid/src/message.ts
@@ -16,24 +16,17 @@ export type MessageLike<
 	TInputs = Record<string, never>,
 	TOptions extends MessageOptions = MessageOptions,
 	TMarkup extends MessageMarkupSchema = MessageMarkupSchema,
-> = ((
-	inputs: TInputs,
-	options?: TOptions
-) => string) & {
+> = ((inputs: TInputs, options?: TOptions) => string) & {
 	parts?: (inputs: TInputs, options?: TOptions) => MessagePart[];
 } & MessageMetadata<TInputs, TOptions, TMarkup>;
 
 type MessageMetadataOf<TMessage extends MessageLike<any, any, any>> =
-	TMessage extends MessageMetadata<
-		infer TInputs,
-		infer TOptions,
-		infer TMarkup
-	>
+	TMessage extends MessageMetadata<infer TInputs, infer TOptions, infer TMarkup>
 		? {
 				inputs: TInputs;
 				options: TOptions;
 				markup: TMarkup;
-		  }
+			}
 		: never;
 
 type MessageInputs<TMessage extends MessageLike<any, any, any>> =
@@ -54,11 +47,12 @@ type NormalizeOptions<TOptions> = [TOptions] extends [undefined]
 		? NonNullable<TOptions>
 		: MessageOptions;
 
-type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> = NormalizeOptions<
-	MessageMetadataOf<TMessage> extends { options: infer TOptions }
-		? TOptions
-		: SignatureOptions<TMessage>
->;
+type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> =
+	NormalizeOptions<
+		MessageMetadataOf<TMessage> extends { options: infer TOptions }
+			? TOptions
+			: SignatureOptions<TMessage>
+	>;
 
 type MessageMarkup<TMessage extends MessageLike<any, any, any>> =
 	MessageMetadataOf<TMessage> extends { markup: infer TMarkup }
@@ -88,9 +82,7 @@ export type MarkupRenderer<
 	TOptions extends MessageOptions = MessageOptions,
 	TTag extends MessageMarkupTag = MessageMarkupTag,
 	TName extends string = string,
-> = (
-	props: MarkupRendererProps<TInputs, TOptions, TTag, TName>
-) => JSX.Element;
+> = (props: MarkupRendererProps<TInputs, TOptions, TTag, TName>) => JSX.Element;
 
 type MarkupRenderersForSchema<
 	TInputs,
@@ -114,11 +106,14 @@ type AnyMarkupRenderer = MarkupRenderer<
 
 type AnyMarkupRenderers = Partial<Record<string, AnyMarkupRenderer>>;
 
+type MessageInputsProp<TInputs> = keyof TInputs extends never
+	? { inputs?: TInputs }
+	: { inputs: TInputs };
+
 type MessageBaseProps<TMessage extends MessageLike<any, any, any>> = {
 	message: TMessage;
-	inputs: MessageInputs<TMessage>;
 	options?: MessageRuntimeOptions<TMessage>;
-};
+} & MessageInputsProp<MessageInputs<TMessage>>;
 
 type MessageMarkupProps<TMessage extends MessageLike<any, any, any>> =
 	keyof MessageMarkup<TMessage> extends never
@@ -143,10 +138,13 @@ type OpenMarkupFrame = {
 	attributes: MessageMarkupAttributes;
 };
 
-export function ParaglideMessage<
-	TMessage extends MessageLike<any, any, any>,
->(props: MessageProps<NoInfer<TMessage>> & { message: TMessage }): JSX.Element {
-	const { message, inputs, options: messageOptions } = props;
+export function ParaglideMessage<TMessage extends MessageLike<any, any, any>>(
+	props: MessageProps<NoInfer<TMessage>> & { message: TMessage }
+): JSX.Element {
+	const { message, options: messageOptions } = props;
+	const inputs =
+		(props as { inputs?: MessageInputs<TMessage> }).inputs ??
+		({} as MessageInputs<TMessage>);
 	const markup = (props as { markup?: AnyMarkupRenderers }).markup;
 	const callableMessage = message as MessageLike<
 		MessageInputs<TMessage>,
@@ -247,17 +245,18 @@ function renderParts<TInputs, TOptions extends MessageOptions = MessageOptions>(
 	return rootChildren;
 }
 
-function renderMarkup<TInputs, TOptions extends MessageOptions = MessageOptions>(
-	args: {
-		name: string;
-		children: JSX.Element[];
-		options: MessageMarkupOptions;
-		attributes: MessageMarkupAttributes;
-		inputs: TInputs;
-		messageOptions?: TOptions;
-		markup?: AnyMarkupRenderers;
-	}
-): JSX.Element {
+function renderMarkup<
+	TInputs,
+	TOptions extends MessageOptions = MessageOptions,
+>(args: {
+	name: string;
+	children: JSX.Element[];
+	options: MessageMarkupOptions;
+	attributes: MessageMarkupAttributes;
+	inputs: TInputs;
+	messageOptions?: TOptions;
+	markup?: AnyMarkupRenderers;
+}): JSX.Element {
 	const renderer = args.markup?.[args.name];
 	const children = toChildren(args.children);
 

--- a/framework/svelte/src/Message.svelte
+++ b/framework/svelte/src/Message.svelte
@@ -8,13 +8,12 @@
 		MessageProps,
 	} from "./message.js";
 
-	const props: MessageProps<TMessage> = $props();
 	const {
 		message,
 		inputs: rawInputs,
 		options,
 		...rest
-	} = props as MessageProps<TMessage> & { inputs?: MessageInputs<TMessage> };
+	}: MessageProps<TMessage> & { inputs?: MessageInputs<TMessage> } = $props();
 	const inputs = $derived(rawInputs ?? ({} as MessageInputs<TMessage>));
 	const markup = rest as unknown as MessageMarkupProps<TMessage>;
 

--- a/framework/svelte/src/Message.svelte
+++ b/framework/svelte/src/Message.svelte
@@ -3,11 +3,19 @@
 	import type {
 		Child,
 		MessageLike,
+		MessageInputs,
 		MessageMarkupProps,
 		MessageProps,
 	} from "./message.js";
 
-	const { message, inputs, options, ...rest }: MessageProps<TMessage> = $props();
+	const props: MessageProps<TMessage> = $props();
+	const {
+		message,
+		inputs: rawInputs,
+		options,
+		...rest
+	} = props as MessageProps<TMessage> & { inputs?: MessageInputs<TMessage> };
+	const inputs = $derived(rawInputs ?? ({} as MessageInputs<TMessage>));
 	const markup = rest as unknown as MessageMarkupProps<TMessage>;
 
 	const parts = $derived.by(() =>

--- a/framework/svelte/src/MessageCTATest.svelte
+++ b/framework/svelte/src/MessageCTATest.svelte
@@ -3,7 +3,7 @@
 	import ParaglideMessage from "./Message.svelte";
 </script>
 
-<ParaglideMessage message={m.cta} inputs={{}}>
+<ParaglideMessage message={m.cta}>
 	{#snippet link({ children, options, attributes })}
 		<a href={options.to} data-track={attributes.track}>
 			{@render children?.()}

--- a/framework/svelte/src/MessageCTAWithComponentTest.svelte
+++ b/framework/svelte/src/MessageCTAWithComponentTest.svelte
@@ -4,7 +4,7 @@
 	import CustomLink from "./CustomLink.svelte";
 </script>
 
-<ParaglideMessage message={m.cta} inputs={{}}>
+<ParaglideMessage message={m.cta}>
 	{#snippet link({ children, options, attributes })}
 		<CustomLink to={options.to} track={attributes.track}>
 			{@render children?.()}

--- a/framework/svelte/src/MessageNestedCTATest.svelte
+++ b/framework/svelte/src/MessageNestedCTATest.svelte
@@ -3,7 +3,7 @@
 	import ParaglideMessage from "./Message.svelte";
 </script>
 
-<ParaglideMessage message={m.nested_cta} inputs={{}}>
+<ParaglideMessage message={m.nested_cta}>
 	{#snippet link({ children, options })}
 		<a href={options.to}>
 			{@render children?.()}

--- a/framework/svelte/src/message.test.ts
+++ b/framework/svelte/src/message.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { compile } from "svelte/compiler";
 import { render } from "svelte/server";
 import { expect, test } from "vitest";
 import { m } from "./paraglide/messages.js";
@@ -42,6 +44,19 @@ test("renders compiled nested markup", () => {
 	expect(normalizeSsrBody(body)).toBe(
 		'<a href="/docs"><strong>Read docs</strong></a>'
 	);
+});
+
+test("keeps Message.svelte props reactive after parent updates", () => {
+	const source = readFileSync(new URL("./Message.svelte", import.meta.url), "utf8");
+	const compiled = compile(source, {
+		filename: "Message.svelte",
+		generate: "client",
+		dev: true,
+	});
+
+	expect(compiled.js.code).toContain("$$props.message");
+	expect(compiled.js.code).toContain("$$props.inputs");
+	expect(compiled.js.code).toContain("$$props.options");
 });
 
 test("enforces markup props at type level", () => {

--- a/framework/svelte/src/message.test.ts
+++ b/framework/svelte/src/message.test.ts
@@ -47,7 +47,10 @@ test("renders compiled nested markup", () => {
 test("enforces markup props at type level", () => {
 	if (false) {
 		// @ts-expect-error markup snippets are required for markup messages
-		renderMessage<typeof m.cta>({ message: m.cta, inputs: {} });
+		renderMessage<typeof m.cta>({ message: m.cta });
+		renderMessage<typeof m.cta>({ message: m.cta, link: undefined as any });
+		// @ts-expect-error inputs are required for messages with parameters
+		renderMessage<typeof m.hello>({ message: m.hello });
 		renderMessage<typeof m.hello>({
 			message: m.hello,
 			inputs: { name: "Ada" },

--- a/framework/svelte/src/message.ts
+++ b/framework/svelte/src/message.ts
@@ -16,27 +16,20 @@ export type MessageLike<
 	TInputs = Record<string, never>,
 	TOptions extends MessageOptions = MessageOptions,
 	TMarkup extends MessageMarkupSchema = MessageMarkupSchema,
-> = ((
-	inputs: TInputs,
-	options?: TOptions
-) => string) & {
+> = ((inputs: TInputs, options?: TOptions) => string) & {
 	parts?: (inputs: TInputs, options?: TOptions) => MessagePart[];
 } & MessageMetadata<TInputs, TOptions, TMarkup>;
 
 type MessageMetadataOf<TMessage extends MessageLike<any, any, any>> =
-	TMessage extends MessageMetadata<
-		infer TInputs,
-		infer TOptions,
-		infer TMarkup
-	>
+	TMessage extends MessageMetadata<infer TInputs, infer TOptions, infer TMarkup>
 		? {
 				inputs: TInputs;
 				options: TOptions;
 				markup: TMarkup;
-		  }
+			}
 		: never;
 
-type MessageInputs<TMessage extends MessageLike<any, any, any>> =
+export type MessageInputs<TMessage extends MessageLike<any, any, any>> =
 	MessageMetadataOf<TMessage> extends { inputs: infer TInputs }
 		? TInputs
 		: Parameters<TMessage> extends [infer TInputs, ...unknown[]]
@@ -54,11 +47,12 @@ type NormalizeOptions<TOptions> = [TOptions] extends [undefined]
 		? NonNullable<TOptions>
 		: MessageOptions;
 
-type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> = NormalizeOptions<
-	MessageMetadataOf<TMessage> extends { options: infer TOptions }
-		? TOptions
-		: SignatureOptions<TMessage>
->;
+type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> =
+	NormalizeOptions<
+		MessageMetadataOf<TMessage> extends { options: infer TOptions }
+			? TOptions
+			: SignatureOptions<TMessage>
+	>;
 
 type MessageMarkup<TMessage extends MessageLike<any, any, any>> =
 	MessageMetadataOf<TMessage> extends { markup: infer TMarkup }
@@ -69,10 +63,11 @@ type MessageMarkup<TMessage extends MessageLike<any, any, any>> =
 
 export type NoInfer<T> = [T][T extends any ? 0 : never];
 
-type MarkupRendererBaseProps<TTag extends MessageMarkupTag = MessageMarkupTag> = {
-	options: TTag["options"];
-	attributes: TTag["attributes"];
-};
+type MarkupRendererBaseProps<TTag extends MessageMarkupTag = MessageMarkupTag> =
+	{
+		options: TTag["options"];
+		attributes: TTag["attributes"];
+	};
 
 export type MarkupRendererProps<
 	TInputs,
@@ -102,20 +97,23 @@ type MarkupRenderersForSchema<
 	>;
 };
 
+type MessageInputsProp<TInputs> = keyof TInputs extends never
+	? { inputs?: TInputs }
+	: { inputs: TInputs };
+
 type MessageBaseProps<TMessage extends MessageLike<any, any, any>> = {
 	message: TMessage;
-	inputs: MessageInputs<TMessage>;
 	options?: MessageRuntimeOptions<TMessage>;
-};
+} & MessageInputsProp<MessageInputs<TMessage>>;
 
 export type MessageMarkupProps<TMessage extends MessageLike<any, any, any>> =
 	keyof MessageMarkup<TMessage> extends never
 		? Record<string, never>
 		: MarkupRenderersForSchema<
-					MessageInputs<TMessage>,
-					MessageRuntimeOptions<TMessage>,
-					MessageMarkup<TMessage>
-			  >;
+				MessageInputs<TMessage>,
+				MessageRuntimeOptions<TMessage>,
+				MessageMarkup<TMessage>
+			>;
 
 export type MessageProps<TMessage extends MessageLike<any, any, any>> =
 	MessageBaseProps<TMessage> & MessageMarkupProps<TMessage>;
@@ -146,7 +144,15 @@ export type OpenMarkupFrame<
 export function renderMessage<TMessage extends MessageLike<any, any, any>>(
 	props: MessageProps<NoInfer<TMessage>> & { message: TMessage }
 ): Child<MessageInputs<TMessage>, MessageRuntimeOptions<TMessage>>[] {
-	const { message, inputs, options, ...rest } = props;
+	const {
+		message,
+		inputs: rawInputs,
+		options,
+		...rest
+	} = props as MessageProps<NoInfer<TMessage>> & {
+		inputs?: MessageInputs<TMessage>;
+	};
+	const inputs = rawInputs ?? ({} as MessageInputs<TMessage>);
 	const markup = rest as unknown as MessageMarkupProps<TMessage>;
 	const callableMessage = message as MessageLike<
 		MessageInputs<TMessage>,

--- a/framework/vue/src/message.test.ts
+++ b/framework/vue/src/message.test.ts
@@ -20,7 +20,6 @@ test("renders compiled markup and exposes options/attributes as records", async 
 		createSSRApp(() =>
 			h(ParaglideMessage, {
 				message: m.cta,
-				inputs: {},
 				markup: {
 					link: ({ children, options, attributes }) =>
 						h(
@@ -44,7 +43,6 @@ test("renders compiled nested markup", async () => {
 		createSSRApp(() =>
 			h(ParaglideMessage, {
 				message: m.nested_cta,
-				inputs: {},
 				markup: {
 					link: ({ children, options }) =>
 						h("a", { href: options.to }, children ?? undefined),
@@ -60,9 +58,19 @@ test("renders compiled nested markup", async () => {
 test("enforces markup props at type level", () => {
 	if (false) {
 		// @ts-expect-error markup renderers are required for markup messages
-		renderMessage<typeof m.cta>({ message: m.cta, inputs: {} });
-		// @ts-expect-error plain messages do not accept a markup prop
-		renderMessage<typeof m.hello>({ message: m.hello, inputs: { name: "Ada" }, markup: { link: () => h("a") } });
+		renderMessage<typeof m.cta>({ message: m.cta });
+		renderMessage<typeof m.cta>({
+			message: m.cta,
+			markup: { link: () => h("a") },
+		});
+		// @ts-expect-error inputs are required for messages with parameters
+		renderMessage<typeof m.hello>({ message: m.hello });
+			renderMessage<typeof m.hello>({
+				message: m.hello,
+				inputs: { name: "Ada" },
+				// @ts-expect-error plain messages do not accept a markup prop
+				markup: { link: () => h("a") },
+			});
 	}
 
 	expect(true).toBe(true);

--- a/framework/vue/src/message.ts
+++ b/framework/vue/src/message.ts
@@ -16,24 +16,17 @@ export type MessageLike<
 	TInputs = Record<string, never>,
 	TOptions extends MessageOptions = MessageOptions,
 	TMarkup extends MessageMarkupSchema = MessageMarkupSchema,
-> = ((
-	inputs: TInputs,
-	options?: TOptions
-) => string) & {
+> = ((inputs: TInputs, options?: TOptions) => string) & {
 	parts?: (inputs: TInputs, options?: TOptions) => MessagePart[];
 } & MessageMetadata<TInputs, TOptions, TMarkup>;
 
 type MessageMetadataOf<TMessage extends MessageLike<any, any, any>> =
-	TMessage extends MessageMetadata<
-		infer TInputs,
-		infer TOptions,
-		infer TMarkup
-	>
+	TMessage extends MessageMetadata<infer TInputs, infer TOptions, infer TMarkup>
 		? {
 				inputs: TInputs;
 				options: TOptions;
 				markup: TMarkup;
-		  }
+			}
 		: never;
 
 type MessageInputs<TMessage extends MessageLike<any, any, any>> =
@@ -54,11 +47,12 @@ type NormalizeOptions<TOptions> = [TOptions] extends [undefined]
 		? NonNullable<TOptions>
 		: MessageOptions;
 
-type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> = NormalizeOptions<
-	MessageMetadataOf<TMessage> extends { options: infer TOptions }
-		? TOptions
-		: SignatureOptions<TMessage>
->;
+type MessageRuntimeOptions<TMessage extends MessageLike<any, any, any>> =
+	NormalizeOptions<
+		MessageMetadataOf<TMessage> extends { options: infer TOptions }
+			? TOptions
+			: SignatureOptions<TMessage>
+	>;
 
 type MessageMarkup<TMessage extends MessageLike<any, any, any>> =
 	MessageMetadataOf<TMessage> extends { markup: infer TMarkup }
@@ -88,9 +82,7 @@ export type MarkupRenderer<
 	TOptions extends MessageOptions = MessageOptions,
 	TTag extends MessageMarkupTag = MessageMarkupTag,
 	TName extends string = string,
-> = (
-	props: MarkupRendererProps<TInputs, TOptions, TTag, TName>
-) => VNodeChild;
+> = (props: MarkupRendererProps<TInputs, TOptions, TTag, TName>) => VNodeChild;
 
 type MarkupRenderersForSchema<
 	TInputs,
@@ -114,11 +106,14 @@ type AnyMarkupRenderer = MarkupRenderer<
 
 type AnyMarkupRenderers = Partial<Record<string, AnyMarkupRenderer>>;
 
+type MessageInputsProp<TInputs> = keyof TInputs extends never
+	? { inputs?: TInputs }
+	: { inputs: TInputs };
+
 type MessageBaseProps<TMessage extends MessageLike<any, any, any>> = {
 	message: TMessage;
-	inputs: MessageInputs<TMessage>;
 	options?: MessageRuntimeOptions<TMessage>;
-};
+} & MessageInputsProp<MessageInputs<TMessage>>;
 
 type MessageMarkupProps<TMessage extends MessageLike<any, any, any>> =
 	keyof MessageMarkup<TMessage> extends never
@@ -149,16 +144,19 @@ type MessageComponent = {
 	): VNodeChild;
 	(props: {
 		message: MessageLike<any, any, any>;
-		inputs: Record<string, unknown>;
+		inputs?: Record<string, unknown>;
 		options?: MessageOptions;
 		markup?: AnyMarkupRenderers;
 	}): VNodeChild;
 };
 
-export function renderMessage<
-	TMessage extends MessageLike<any, any, any>,
->(props: MessageProps<NoInfer<TMessage>> & { message: TMessage }): VNodeChild {
-	const { message, inputs, options: messageOptions } = props;
+export function renderMessage<TMessage extends MessageLike<any, any, any>>(
+	props: MessageProps<NoInfer<TMessage>> & { message: TMessage }
+): VNodeChild {
+	const { message, options: messageOptions } = props;
+	const inputs =
+		(props as { inputs?: MessageInputs<TMessage> }).inputs ??
+		({} as MessageInputs<TMessage>);
 	const markup = (props as { markup?: AnyMarkupRenderers }).markup;
 	const callableMessage = message as MessageLike<
 		MessageInputs<TMessage>,
@@ -189,7 +187,7 @@ export const ParaglideMessage = defineComponent({
 		},
 		inputs: {
 			type: Object as PropType<Record<string, unknown>>,
-			required: true,
+			required: false,
 		},
 		options: {
 			type: Object as PropType<MessageOptions>,
@@ -290,17 +288,18 @@ function renderParts<TInputs, TOptions extends MessageOptions = MessageOptions>(
 	return rootChildren;
 }
 
-function renderMarkup<TInputs, TOptions extends MessageOptions = MessageOptions>(
-	args: {
-		name: string;
-		children: VNodeChild[];
-		options: MessageMarkupOptions;
-		attributes: MessageMarkupAttributes;
-		inputs: TInputs;
-		messageOptions?: TOptions;
-		markup?: AnyMarkupRenderers;
-	}
-): VNodeChild {
+function renderMarkup<
+	TInputs,
+	TOptions extends MessageOptions = MessageOptions,
+>(args: {
+	name: string;
+	children: VNodeChild[];
+	options: MessageMarkupOptions;
+	attributes: MessageMarkupAttributes;
+	inputs: TInputs;
+	messageOptions?: TOptions;
+	markup?: AnyMarkupRenderers;
+}): VNodeChild {
 	const renderer = args.markup?.[args.name];
 	const children = toChildren(args.children);
 


### PR DESCRIPTION
## Summary

- Make `ParaglideMessage` inputs optional for messages without parameters across React, Solid, Svelte, and Vue adapters.
- Default missing runtime inputs to `{}` before calling compiled message functions or `parts()`.
- Add adapter test coverage and a patch changeset for all four framework packages.

## Validation

- `pnpm --dir framework/react test`
- `pnpm --dir framework/solid test`
- `pnpm --dir framework/vue test`
- `pnpm --dir framework/svelte test`
- `git diff --check`

closes https://github.com/opral/paraglide-js/issues/681

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message-rendering entrypoints across four framework adapters; main risk is type/runtime mismatches from defaulting missing `inputs` to `{}` and making Vue props optional.
> 
> **Overview**
> **Makes `inputs` optional for parameterless messages across React, Solid, Svelte, and Vue adapters.** When `inputs` is omitted, the adapters now default to `{}` before calling the compiled message function or `parts()`.
> 
> Updates type-level enforcement/tests to require `inputs` only for messages with parameters, adjusts Svelte/Vue component props accordingly (including Vue `inputs` no longer `required`), and adds a Svelte client-compile test to ensure `Message.svelte` props remain reactive after parent updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb1411724bd9ef54c93370eaf2455d2495a3a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->