### PR TITLE
docs(astro example): drop doubled 'about' in Astro middleware link sentence

### DIFF
--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -59,7 +59,7 @@ export const onRequest = defineMiddleware((context, next) => {
 });
 ```
 
-You can read more about about Astro's middleware [here](https://docs.astro.build/en/guides/middleware).
+You can read more about Astro's middleware [here](https://docs.astro.build/en/guides/middleware).
 
 ## Usage
 


### PR DESCRIPTION
Tiny typo fix in `examples/astro/README.md` — the sentence read "read more about about Astro's middleware". Dropped the duplicate word.