### PR TITLE
Fix CLI watch outdir cleanup

### DIFF
--- a/.changeset/fair-bikes-watch.md
+++ b/.changeset/fair-bikes-watch.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Prevent `paraglide-js compile --watch` from cleaning the output directory on the initial compile.

--- a/src/bundler-plugins/unplugin.ts
+++ b/src/bundler-plugins/unplugin.ts
@@ -1,6 +1,6 @@
 import type { UnpluginFactory } from "unplugin";
 import { compile, type CompilationResult } from "../compiler/compile.js";
-import path, { relative } from "node:path";
+import { relative } from "node:path";
 import { Logger } from "../services/logger/index.js";
 import type { CompilerOptions } from "../compiler/compiler-options.js";
 import {
@@ -9,7 +9,7 @@ import {
 	isPathWithinDirectories,
 } from "../services/file-watching/tracked-fs.js";
 import { nodeNormalizePath } from "../utilities/node-normalize-path.js";
-import { hashDirectory } from "../services/file-handling/write-output.js";
+import { seedPreviousCompilationFromOutdir } from "../compiler/seed-previous-compilation.js";
 
 const PLUGIN_NAME = "unplugin-paraglide-js";
 
@@ -31,26 +31,6 @@ function withoutCleanOutdir(
 	return compileArgs;
 }
 
-/**
- * Seed a synthetic `previousCompilation` from files already on disk in
- * `outdir`. This lets the first compile in a fresh process diff against
- * the prior build's output instead of treating it as empty — so warm
- * restarts produce zero writes and we never wipe `outdir` out from under
- * concurrent readers (SSR/prerender, sibling Vite processes).
- *
- * See https://github.com/opral/inlang-paraglide-js/issues/659.
- */
-async function seedPreviousCompilation(
-	outdir: string,
-	fs: typeof import("node:fs") | undefined
-): Promise<CompilationResult | undefined> {
-	const absoluteOutdir = path.resolve(process.cwd(), outdir);
-	const resolvedFs = fs ?? (await import("node:fs"));
-	const outputHashes = await hashDirectory(absoluteOutdir, resolvedFs.promises);
-	if (!outputHashes) return undefined;
-	return { outputHashes };
-}
-
 export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 	name: PLUGIN_NAME,
 	enforce: "pre",
@@ -67,7 +47,10 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 			// racing concurrent readers that wiping outdir would interrupt.
 			const seededPrevious =
 				previousCompilation ??
-				(await seedPreviousCompilation(args.outdir, args.fs));
+				(await seedPreviousCompilationFromOutdir({
+					outdir: args.outdir,
+					fs: args.fs?.promises,
+				}));
 			previousCompilation = await compile({
 				fs: trackedFs,
 				previousCompilation: seededPrevious,
@@ -184,7 +167,10 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 			try {
 				const seededPrevious =
 					previousCompilation ??
-					(await seedPreviousCompilation(args.outdir, args.fs));
+					(await seedPreviousCompilationFromOutdir({
+						outdir: args.outdir,
+						fs: args.fs?.promises,
+					}));
 				previousCompilation = await compile({
 					fs: trackedFs,
 					previousCompilation: seededPrevious,

--- a/src/cli/commands/compile/command.test.ts
+++ b/src/cli/commands/compile/command.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import * as nodeFs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+let testDirectories: string[] = [];
+let initialSigintListeners: NodeJS.SignalsListener[] = [];
+
+beforeEach(() => {
+	vi.resetModules();
+	testDirectories = [];
+	initialSigintListeners = process.listeners("SIGINT");
+});
+
+afterEach(async () => {
+	for (const listener of process.listeners("SIGINT")) {
+		if (!initialSigintListeners.includes(listener)) {
+			process.removeListener("SIGINT", listener);
+		}
+	}
+	for (const directory of testDirectories) {
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+test("compile --watch seeds existing outdir and disables cleaning on first compile (#688)", async () => {
+	const testDirectory = await mkdtemp(path.join(tmpdir(), "paraglide-cli-"));
+	testDirectories.push(testDirectory);
+	const outdir = path.join(testDirectory, "output");
+	const { writeOutput } = await import(
+		"../../../services/file-handling/write-output.js"
+	);
+	await writeOutput({
+		directory: outdir,
+		output: {
+			"runtime.js": "export const runtime = true;",
+		},
+		fs: nodeFs,
+	});
+
+	const compileMock = vi.fn().mockResolvedValue({
+		outputHashes: {
+			"runtime.js": "next-hash",
+		},
+	});
+	vi.doMock("../../../compiler/compile.js", () => ({
+		compile: compileMock,
+	}));
+
+	const { compileCommand } = await import("./command.js");
+
+	await compileCommand.parseAsync(
+		[
+			"--project",
+			path.join(testDirectory, "project.inlang"),
+			"--outdir",
+			outdir,
+			"--watch",
+			"--silent",
+		],
+		{ from: "user" }
+	);
+
+	expect(compileMock).toHaveBeenCalledTimes(1);
+	expect(compileMock).toHaveBeenCalledWith(
+		expect.objectContaining({
+			outdir,
+			cleanOutdir: false,
+			previousCompilation: {
+				outputHashes: {
+					"runtime.js": expect.any(String),
+				},
+			},
+		})
+	);
+});

--- a/src/cli/commands/compile/command.ts
+++ b/src/cli/commands/compile/command.ts
@@ -4,6 +4,7 @@ import { resolve, relative } from "node:path";
 import { Logger } from "../../../services/logger/index.js";
 import { DEFAULT_OUTDIR, DEFAULT_PROJECT_PATH } from "../../defaults.js";
 import { compile, type CompilationResult } from "../../../compiler/compile.js";
+import { seedPreviousCompilationFromOutdir } from "../../../compiler/seed-previous-compilation.js";
 import {
 	defaultCompilerOptions,
 	type CompilerOptions,
@@ -257,11 +258,17 @@ export const compileCommand = new Command()
 				}
 
 				try {
+					const seededPrevious =
+						previousCompilation ??
+						(await seedPreviousCompilationFromOutdir({
+							outdir: compileOptions.outdir,
+						}));
+
 					previousCompilation = await compile({
 						...compileOptions,
 						fs: trackedFs,
-						previousCompilation,
-						cleanOutdir: previousCompilation === undefined,
+						previousCompilation: seededPrevious,
+						cleanOutdir: false,
 					});
 
 					if (changedPath) {

--- a/src/compiler/seed-previous-compilation.ts
+++ b/src/compiler/seed-previous-compilation.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import nodeFs from "node:fs/promises";
+import type { CompilationResult } from "./compile.js";
+import { hashDirectory } from "../services/file-handling/write-output.js";
+
+export async function seedPreviousCompilationFromOutdir(args: {
+	outdir: string;
+	fs?: typeof nodeFs;
+	cwd?: string;
+}): Promise<CompilationResult | undefined> {
+	const absoluteOutdir = path.resolve(args.cwd ?? process.cwd(), args.outdir);
+	const outputHashes = await hashDirectory(absoluteOutdir, args.fs ?? nodeFs);
+
+	return outputHashes ? { outputHashes } : undefined;
+}


### PR DESCRIPTION
## Summary
- seed CLI watch compilations from existing outdir hashes before the first compile
- keep watch mode from cleaning the outdir on startup
- share the existing outdir seeding logic with the bundler plugin path
- add a regression test for `paraglide-js compile --watch`

## Tests
- `npm run env-variables && pnpm exec tsc --noEmit`
- `pnpm vitest run src/cli/commands/compile/command.test.ts src/bundler-plugins/unplugin.test.ts src/services/file-handling/write-output.test.ts`
- `pnpm test`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted compile/watch output behavior with tests; one-shot `compile` without `--watch` is unchanged.
> 
> **Overview**
> **`paraglide-js compile --watch`** no longer wipes the output folder on the first run. Watch mode now **hashes whatever is already in `outdir`** and passes that as `previousCompilation`, with **`cleanOutdir: false`**, so a restart can skip redundant writes and avoid breaking readers (SSR, other processes) that still depend on files in that directory.
> 
> The same **outdir seeding** logic used by the bundler plugin is moved into **`seedPreviousCompilationFromOutdir`**, and the unplugin path calls that helper instead of duplicating it locally. A **regression test** locks in the watch startup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bea31af8225890e69911db3acf3b9106fde80ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->