### PR TITLE
[codex] Fix dotted key declaration aliases

### DIFF
--- a/.changeset/quiet-rivers-quote.md
+++ b/.changeset/quiet-rivers-quote.md
@@ -1,0 +1,7 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix emitted TypeScript declarations for message keys that require quoted export aliases, such as dotted nested keys.
+
+`emitTsDeclarations` now preserves quoted aliases from the generated JavaScript so `.d.ts` output remains valid for keys like `greeting.hello`. The optional TypeScript peer dependency now requires TypeScript 5.6 or newer, which supports arbitrary quoted module export names.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"urlpattern-polyfill": "^10.0.0"
 	},
 	"peerDependencies": {
-		"typescript": ">=5"
+		"typescript": ">=5.6"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -268,6 +268,82 @@ test("emitTsDeclarations generates declaration files", async () => {
 	expect(diagnostics.length).toEqual(0);
 });
 
+test("emitTsDeclarations quotes unsafe export aliases", async () => {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				locales: ["en"],
+				baseLocale: "en",
+			},
+		}),
+	});
+
+	await insertBundleNested(
+		project.db,
+		createBundleNested({
+			id: "greeting.hello",
+			messages: [
+				{
+					locale: "en",
+					variants: [{ pattern: [{ type: "text", value: "Hello" }] }],
+				},
+			],
+		})
+	);
+
+	for (const outputStructure of [
+		"message-modules",
+		"locale-modules",
+	] as const) {
+		const output = await compileProject({
+			project,
+			compilerOptions: {
+				emitTsDeclarations: true,
+				outputStructure,
+			},
+		});
+		const declarationFile =
+			outputStructure === "message-modules"
+				? "messages/greeting_hello.d.ts"
+				: "messages/_index.d.ts";
+
+		expect(output[declarationFile]).toContain(
+			`export { greeting_hello as "greeting.hello" };`
+		);
+
+		const tsProject = await typescriptProject({
+			useInMemoryFileSystem: true,
+			compilerOptions: {
+				module: ts.ModuleKind.Node16,
+				moduleResolution: ts.ModuleResolutionKind.Node16,
+				strict: true,
+			},
+		});
+
+		for (const [fileName, code] of Object.entries(output)) {
+			if (fileName.endsWith(".d.ts")) {
+				tsProject.createSourceFile(fileName, code);
+			}
+		}
+
+		tsProject.createSourceFile(
+			"test.ts",
+			`
+				import { "greeting.hello" as greetingHello } from "./messages.js";
+
+				greetingHello() satisfies string;
+			`
+		);
+
+		const program = tsProject.createProgram();
+		const diagnostics = ts.getPreEmitDiagnostics(program);
+		for (const diagnostic of diagnostics) {
+			console.error(diagnostic.messageText, diagnostic.file?.fileName);
+		}
+		expect(diagnostics.length).toEqual(0);
+	}
+});
+
 test("handles message bundles with a : in the id", async () => {
 	const project = await loadProjectInMemory({
 		blob: await newProject({

--- a/src/compiler/emit-ts-declarations.ts
+++ b/src/compiler/emit-ts-declarations.ts
@@ -45,6 +45,7 @@ export async function emitTsDeclarations(
 			content,
 		])
 	);
+	const quotedExportAliases = collectQuotedExportAliases(ts, files);
 
 	const virtualDirectories = new Set(
 		Array.from(files.keys()).flatMap((filePath) => {
@@ -145,9 +146,148 @@ export async function emitTsDeclarations(
 		host
 	);
 
-	program.emit(undefined, undefined, undefined, true);
+	program.emit(undefined, undefined, undefined, true, {
+		afterDeclarations: [
+			createQuotedExportAliasTransformer(
+				ts,
+				quotedExportAliases,
+				normalizeFileName
+			),
+		],
+	});
 
 	return declarations;
+}
+
+type QuotedExportAliases = Map<string, Map<string, Set<string>>>;
+
+function collectQuotedExportAliases(
+	ts: TypeScript,
+	files: Map<string, string>
+): QuotedExportAliases {
+	const aliases: QuotedExportAliases = new Map();
+
+	for (const [fileName, content] of files) {
+		const sourceFile = ts.createSourceFile(
+			fileName,
+			content,
+			ts.ScriptTarget.ESNext,
+			true,
+			ts.ScriptKind.JS
+		);
+		const fileAliases = new Map<string, Set<string>>();
+
+		const visit = (node: import("typescript").Node) => {
+			if (
+				ts.isExportDeclaration(node) &&
+				node.exportClause &&
+				ts.isNamedExports(node.exportClause)
+			) {
+				for (const specifier of node.exportClause.elements) {
+					if (ts.isStringLiteral(specifier.name)) {
+						const localName = moduleExportNameText(
+							specifier.propertyName ?? specifier.name
+						);
+						const exportedName = specifier.name.text;
+						const localAliases =
+							fileAliases.get(localName) ?? new Set<string>();
+						localAliases.add(exportedName);
+						fileAliases.set(localName, localAliases);
+					}
+				}
+			}
+			ts.forEachChild(node, visit);
+		};
+
+		visit(sourceFile);
+
+		if (fileAliases.size > 0) {
+			aliases.set(fileName, fileAliases);
+		}
+	}
+
+	return aliases;
+}
+
+function createQuotedExportAliasTransformer(
+	ts: TypeScript,
+	quotedExportAliases: QuotedExportAliases,
+	normalizeFileName: (fileName: string) => string
+): import("typescript").TransformerFactory<
+	import("typescript").SourceFile | import("typescript").Bundle
+> {
+	return (context) => {
+		const visitSourceFile = (sourceFile: import("typescript").SourceFile) => {
+			const fileAliases = quotedExportAliases.get(
+				normalizeFileName(sourceFile.fileName)
+			);
+
+			if (!fileAliases) {
+				return sourceFile;
+			}
+
+			const visit = (
+				node: import("typescript").Node
+			): import("typescript").VisitResult<import("typescript").Node> => {
+				if (
+					ts.isExportDeclaration(node) &&
+					node.exportClause &&
+					ts.isNamedExports(node.exportClause)
+				) {
+					const elements: import("typescript").ExportSpecifier[] = [];
+					const emitted = new Set<string>();
+
+					for (const specifier of node.exportClause.elements) {
+						const localName = moduleExportNameText(
+							specifier.propertyName ?? specifier.name
+						);
+						const exportedName = moduleExportNameText(specifier.name);
+						const shouldQuote = fileAliases.get(localName)?.has(exportedName);
+						const nextSpecifier = shouldQuote
+							? ts.factory.updateExportSpecifier(
+									specifier,
+									specifier.isTypeOnly,
+									specifier.propertyName,
+									ts.factory.createStringLiteral(exportedName)
+								)
+							: specifier;
+						const emittedKey = `${moduleExportNameText(
+							nextSpecifier.propertyName ?? nextSpecifier.name
+						)}\0${moduleExportNameText(nextSpecifier.name)}`;
+
+						if (!emitted.has(emittedKey)) {
+							elements.push(nextSpecifier);
+							emitted.add(emittedKey);
+						}
+					}
+
+					return ts.factory.updateExportDeclaration(
+						node,
+						node.modifiers,
+						node.isTypeOnly,
+						ts.factory.updateNamedExports(node.exportClause, elements),
+						node.moduleSpecifier,
+						node.attributes
+					);
+				}
+
+				return ts.visitEachChild(node, visit, context);
+			};
+
+			return ts.visitEachChild(sourceFile, visit, context);
+		};
+
+		return (sourceFileOrBundle) => {
+			if ("fileName" in sourceFileOrBundle) {
+				return visitSourceFile(sourceFileOrBundle);
+			}
+			return sourceFileOrBundle;
+		};
+	};
+}
+
+function moduleExportNameText(name: import("typescript").ModuleExportName) {
+	return name.text;
 }
 
 async function importTypeScript(): Promise<TypeScript> {


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/690

## Summary

- Preserve quoted export aliases when emitting `.d.ts` files for unsafe message keys like `greeting.hello`
- Add regression coverage for both `message-modules` and `locale-modules`
- Require TypeScript `>=5.6` for `emitTsDeclarations`, matching arbitrary quoted module export/import name support
- Add a patch changeset

## Root Cause

TypeScript's JS declaration emit can drop quotes from string-literal export aliases, producing invalid declarations such as `export { greeting_hello as greeting.hello };` even though the generated JavaScript is valid.

## Validation

- `pnpm exec vitest run src/compiler/compile-project.test.ts --coverage=false`
- `npm run env-variables && pnpm exec tsc --noEmit`
- `git diff --check main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to optional declaration emit and a peer dependency floor bump; no runtime message or auth changes.
> 
> **Overview**
> Fixes **invalid `.d.ts` output** when message keys need **quoted export aliases** (e.g. nested keys like `greeting.hello`). TypeScript’s declaration emit from JS could drop quotes and emit unusable exports such as `export { greeting_hello as greeting.hello };` even though the generated JavaScript is correct.
> 
> `emitTsDeclarations` now **reads quoted aliases from the emitted JS** and runs an **`afterDeclarations` transformer** so declaration files keep forms like `export { greeting_hello as "greeting.hello" };`. A regression test covers **`message-modules`** and **`locale-modules`**, including importing with `import { "greeting.hello" as ... }`.
> 
> The optional **TypeScript peer dependency** is raised to **`>=5.6`** to align with support for arbitrary quoted module export/import names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfa099f91e13d4f800e22073e7053ad72463864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->