### PR TITLE
fix(compiler): compile pattern-level function-reference annotations to registry calls

### DIFF
--- a/.changeset/pattern-level-annotations.md
+++ b/.changeset/pattern-level-annotations.md
@@ -1,0 +1,18 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Compile pattern-level function-reference annotations to registry calls
+
+Annotations attached directly to pattern expressions (e.g. i18next's `{{count, number}}` imported via plugin-i18next) were silently dropped and compiled to plain interpolation. They now compile through the same `registry.*` path as local-variable annotations:
+
+```js
+// before
+const en_views = (i) => `${i?.count} views`;
+// after
+const en_views = (i) => `${registry.number("en", i?.count, {})} views`;
+```
+
+Unknown formatter names fall back to plain interpolation with a compile-time warning instead of failing or staying silent. `compilePattern()` gained an optional `locale` parameter, required to compile annotations.
+
+Fixes https://github.com/opral/paraglide-js/issues/694

--- a/src/compiler/compile-annotation.ts
+++ b/src/compiler/compile-annotation.ts
@@ -1,0 +1,204 @@
+import type {
+	FunctionReference,
+	Literal,
+	VariableReference,
+} from "@inlang/sdk";
+import { compileInputAccess } from "./variable-access.js";
+import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
+
+/**
+ * The functions shipped in the generated registry.js file.
+ *
+ * @see createRegistry()
+ */
+const registryFunctionNames = new Set([
+	"plural",
+	"number",
+	"datetime",
+	"relativetime",
+]);
+
+export function isRegistryFunction(name: string): boolean {
+	return registryFunctionNames.has(name);
+}
+
+export function registryFunctionNamesForDisplay(): string {
+	return Array.from(registryFunctionNames).join(", ");
+}
+
+/**
+ * Wraps a compiled expression value in a `registry.*` call if an
+ * annotation is present.
+ *
+ * @example
+ *   compileAnnotation("i?.count", "en", { type: "function-reference", name: "number", options: [] })
+ *   >> 'registry.number("en", i?.count, {})'
+ */
+export function compileAnnotation(
+	str: string,
+	locale: string,
+	annotation?: FunctionReference
+): string {
+	if (!annotation) {
+		return str;
+	}
+	if (annotation.name === "relativetime") {
+		validateRelativeTimeOptions(annotation);
+	}
+	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options)})`;
+}
+
+function compileOptions(
+	annotationName: string,
+	options: FunctionReference["options"]
+): string {
+	if (options.length === 0) {
+		return "{}";
+	}
+	const entries: string[] = options.map(
+		(option) =>
+			`${option.name}: ${compileOptionLiteralOrVarRef(
+				annotationName,
+				option.name,
+				option.value
+			)}`
+	);
+	const code = "{ " + entries.join(", ") + " }";
+
+	return code;
+}
+
+const numericOptionNamesByAnnotation: Record<string, ReadonlySet<string>> = {
+	number: new Set([
+		"minimumIntegerDigits",
+		"minimumFractionDigits",
+		"maximumFractionDigits",
+		"minimumSignificantDigits",
+		"maximumSignificantDigits",
+		"roundingIncrement",
+	]),
+	plural: new Set([
+		"minimumIntegerDigits",
+		"minimumFractionDigits",
+		"maximumFractionDigits",
+		"minimumSignificantDigits",
+		"maximumSignificantDigits",
+	]),
+	datetime: new Set(["fractionalSecondDigits"]),
+};
+
+const booleanOptionNamesByAnnotation: Record<string, ReadonlySet<string>> = {
+	number: new Set(["useGrouping"]),
+	datetime: new Set(["hour12"]),
+};
+
+const jsNonNegativeIntegerPattern = /^(?:0|[1-9]\d*)$/;
+
+function compileOptionLiteralOrVarRef(
+	annotationName: string,
+	optionName: string,
+	value: Literal | VariableReference
+): string {
+	if (value.type === "variable-reference") {
+		if (annotationName === "relativetime" && optionName === "unit") {
+			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.name)})`;
+		}
+		return compileInputAccess(value.name);
+	}
+
+	if (
+		annotationName === "relativetime" &&
+		optionName === "unit" &&
+		isDollarVariableReference(value.value)
+	) {
+		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.value.slice(1))})`;
+	}
+
+	if (shouldEmitNumberLiteral(annotationName, optionName, value.value)) {
+		return value.value;
+	}
+
+	if (shouldEmitBooleanLiteral(annotationName, optionName, value.value)) {
+		return value.value;
+	}
+
+	return `"${escapeForDoubleQuoteString(value.value)}"`;
+}
+
+function shouldEmitNumberLiteral(
+	annotationName: string,
+	optionName: string,
+	literal: string
+): boolean {
+	return (
+		numericOptionNamesByAnnotation[annotationName]?.has(optionName) === true &&
+		jsNonNegativeIntegerPattern.test(literal)
+	);
+}
+
+function shouldEmitBooleanLiteral(
+	annotationName: string,
+	optionName: string,
+	literal: string
+): boolean {
+	return (
+		booleanOptionNamesByAnnotation[annotationName]?.has(optionName) === true &&
+		(literal === "true" || literal === "false")
+	);
+}
+
+const relativeTimeUnits = new Set([
+	"year",
+	"years",
+	"quarter",
+	"quarters",
+	"month",
+	"months",
+	"week",
+	"weeks",
+	"day",
+	"days",
+	"hour",
+	"hours",
+	"minute",
+	"minutes",
+	"second",
+	"seconds",
+]);
+
+function validateRelativeTimeOptions(annotation: FunctionReference): void {
+	const unitOptions = annotation.options.filter(
+		(option) => option.name === "unit"
+	);
+
+	if (unitOptions.length === 0) {
+		throw new Error('The "relativetime" formatter requires a "unit" option.');
+	}
+
+	if (unitOptions.length > 1) {
+		throw new Error(
+			'The "relativetime" formatter requires exactly one "unit" option.'
+		);
+	}
+
+	const [unitOption] = unitOptions;
+	if (!unitOption || unitOption.value.type === "variable-reference") {
+		return;
+	}
+
+	if (isDollarVariableReference(unitOption.value.value)) {
+		return;
+	}
+
+	if (!relativeTimeUnits.has(unitOption.value.value)) {
+		throw new Error(
+			`Invalid "relativetime" unit "${unitOption.value.value}". Expected one of: ${Array.from(
+				relativeTimeUnits
+			).join(", ")}.`
+		);
+	}
+}
+
+function isDollarVariableReference(value: string): boolean {
+	return value.startsWith("$") && value.length > 1;
+}

--- a/src/compiler/compile-local-variable.ts
+++ b/src/compiler/compile-local-variable.ts
@@ -1,11 +1,7 @@
-import type {
-	FunctionReference,
-	Literal,
-	LocalVariable,
-	VariableReference,
-} from "@inlang/sdk";
+import type { Literal, LocalVariable, VariableReference } from "@inlang/sdk";
 import { compileInputAccess } from "./variable-access.js";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
+import { compileAnnotation } from "./compile-annotation.js";
 
 /**
  * Compiles a local variable.
@@ -33,119 +29,6 @@ export function compileLocalVariable(args: {
 	return `const ${args.declaration.name} = ${value};`;
 }
 
-function compileAnnotation(
-	str: string,
-	locale: string,
-	annotation?: LocalVariable["value"]["annotation"]
-): string {
-	if (!annotation) {
-		return str;
-	}
-	if (annotation.name === "relativetime") {
-		validateRelativeTimeOptions(annotation);
-	}
-	return `registry.${annotation.name}("${locale}", ${str}, ${compileOptions(annotation.name, annotation.options)})`;
-}
-
-function compileOptions(
-	annotationName: string,
-	options: FunctionReference["options"]
-): string {
-	if (options.length === 0) {
-		return "{}";
-	}
-	const entries: string[] = options.map(
-		(option) =>
-			`${option.name}: ${compileOptionLiteralOrVarRef(
-				annotationName,
-				option.name,
-				option.value
-			)}`
-	);
-	const code = "{ " + entries.join(", ") + " }";
-
-	return code;
-}
-
-const numericOptionNamesByAnnotation: Record<string, ReadonlySet<string>> = {
-	number: new Set([
-		"minimumIntegerDigits",
-		"minimumFractionDigits",
-		"maximumFractionDigits",
-		"minimumSignificantDigits",
-		"maximumSignificantDigits",
-		"roundingIncrement",
-	]),
-	plural: new Set([
-		"minimumIntegerDigits",
-		"minimumFractionDigits",
-		"maximumFractionDigits",
-		"minimumSignificantDigits",
-		"maximumSignificantDigits",
-	]),
-	datetime: new Set(["fractionalSecondDigits"]),
-};
-
-const booleanOptionNamesByAnnotation: Record<string, ReadonlySet<string>> = {
-	number: new Set(["useGrouping"]),
-	datetime: new Set(["hour12"]),
-};
-
-const jsNonNegativeIntegerPattern = /^(?:0|[1-9]\d*)$/;
-
-function compileOptionLiteralOrVarRef(
-	annotationName: string,
-	optionName: string,
-	value: Literal | VariableReference
-): string {
-	if (value.type === "variable-reference") {
-		if (annotationName === "relativetime" && optionName === "unit") {
-			return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.name)})`;
-		}
-		return compileInputAccess(value.name);
-	}
-
-	if (
-		annotationName === "relativetime" &&
-		optionName === "unit" &&
-		isDollarVariableReference(value.value)
-	) {
-		return `/** @type {import("../registry.js").RelativeTimeFormatUnit} */ (${compileInputAccess(value.value.slice(1))})`;
-	}
-
-	if (shouldEmitNumberLiteral(annotationName, optionName, value.value)) {
-		return value.value;
-	}
-
-	if (shouldEmitBooleanLiteral(annotationName, optionName, value.value)) {
-		return value.value;
-	}
-
-	return `"${escapeForDoubleQuoteString(value.value)}"`;
-}
-
-function shouldEmitNumberLiteral(
-	annotationName: string,
-	optionName: string,
-	literal: string
-): boolean {
-	return (
-		numericOptionNamesByAnnotation[annotationName]?.has(optionName) === true &&
-		jsNonNegativeIntegerPattern.test(literal)
-	);
-}
-
-function shouldEmitBooleanLiteral(
-	annotationName: string,
-	optionName: string,
-	literal: string
-): boolean {
-	return (
-		booleanOptionNamesByAnnotation[annotationName]?.has(optionName) === true &&
-		(literal === "true" || literal === "false")
-	);
-}
-
 function compileLiteralOrVarRef(value: Literal | VariableReference): string {
 	switch (value.type) {
 		case "literal":
@@ -153,60 +36,4 @@ function compileLiteralOrVarRef(value: Literal | VariableReference): string {
 		case "variable-reference":
 			return compileInputAccess(value.name);
 	}
-}
-
-const relativeTimeUnits = new Set([
-	"year",
-	"years",
-	"quarter",
-	"quarters",
-	"month",
-	"months",
-	"week",
-	"weeks",
-	"day",
-	"days",
-	"hour",
-	"hours",
-	"minute",
-	"minutes",
-	"second",
-	"seconds",
-]);
-
-function validateRelativeTimeOptions(annotation: FunctionReference): void {
-	const unitOptions = annotation.options.filter(
-		(option) => option.name === "unit"
-	);
-
-	if (unitOptions.length === 0) {
-		throw new Error('The "relativetime" formatter requires a "unit" option.');
-	}
-
-	if (unitOptions.length > 1) {
-		throw new Error(
-			'The "relativetime" formatter requires exactly one "unit" option.'
-		);
-	}
-
-	const [unitOption] = unitOptions;
-	if (!unitOption || unitOption.value.type === "variable-reference") {
-		return;
-	}
-
-	if (isDollarVariableReference(unitOption.value.value)) {
-		return;
-	}
-
-	if (!relativeTimeUnits.has(unitOption.value.value)) {
-		throw new Error(
-			`Invalid "relativetime" unit "${unitOption.value.value}". Expected one of: ${Array.from(
-				relativeTimeUnits
-			).join(", ")}.`
-		);
-	}
-}
-
-function isDollarVariableReference(value: string): boolean {
-	return value.startsWith("$") && value.length > 1;
 }

--- a/src/compiler/compile-message.test.ts
+++ b/src/compiler/compile-message.test.ts
@@ -30,6 +30,104 @@ test("compiles a message with a single variant", async () => {
 	expect(some_message()).toBe("Hello");
 });
 
+test("compiles pattern-level annotations to registry calls", async () => {
+	// https://github.com/opral/paraglide-js/issues/694
+	// i18next's `{{count, number}}` imports as an expression with a
+	// function-reference annotation directly on the pattern.
+	const declarations: Declaration[] = [{ type: "input-variable", name: "count" }];
+	const message: Message = {
+		locale: "en",
+		bundleId: "views",
+		id: "message-id",
+		selectors: [],
+	};
+	const variants: Variant[] = [
+		{
+			id: "1",
+			messageId: "message-id",
+			matches: [],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+				{ type: "text", value: " views" },
+			],
+		},
+	];
+
+	const compiled = compileMessage(declarations, message, variants);
+
+	expect(compiled.code).toContain('registry.number("en", i?.count, {})');
+
+	const { views } = await import(
+		"data:text/javascript;base64," +
+			// bundling the registry inline to avoid managing module imports here
+			btoa(
+				createRegistry() +
+					"\nexport const views = " +
+					compiled.code.replaceAll("registry.", "")
+			)
+	);
+
+	expect(views({ count: 1234567.891 })).toBe("1,234,567.891 views");
+});
+
+test("compiles pattern-level annotations in multi-variant messages", async () => {
+	const declarations: Declaration[] = [{ type: "input-variable", name: "count" }];
+	const message: Message = {
+		locale: "en",
+		bundleId: "views_multi",
+		id: "message-id",
+		selectors: [{ type: "variable-reference", name: "count" }],
+	};
+	const variants: Variant[] = [
+		{
+			id: "1",
+			messageId: "message-id",
+			matches: [{ type: "literal-match", key: "count", value: "1" }],
+			pattern: [{ type: "text", value: "One view" }],
+		},
+		{
+			id: "2",
+			messageId: "message-id",
+			matches: [{ type: "catchall-match", key: "count" }],
+			pattern: [
+				{
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+				{ type: "text", value: " views" },
+			],
+		},
+	];
+
+	const compiled = compileMessage(declarations, message, variants);
+
+	const { views_multi } = await import(
+		"data:text/javascript;base64," +
+			// bundling the registry inline to avoid managing module imports here
+			btoa(
+				createRegistry() +
+					"\nexport const views_multi = " +
+					compiled.code.replaceAll("registry.", "")
+			)
+	);
+
+	expect(views_multi({ count: 1 })).toBe("One view");
+	expect(views_multi({ count: 1234567.891 })).toBe("1,234,567.891 views");
+});
+
 test("compiles a markup message with .parts()", async () => {
 	const declarations: Declaration[] = [
 		{ type: "input-variable", name: "amount" },

--- a/src/compiler/compile-message.ts
+++ b/src/compiler/compile-message.ts
@@ -59,6 +59,7 @@ function compileMessageWithOneVariant(
 	const compiledPattern = compilePattern({
 		pattern: variant.pattern,
 		declarations,
+		locale: message.locale,
 	});
 
 	const compiledLocalVariables = [];
@@ -83,6 +84,7 @@ function compileMessageWithOneVariant(
 		pattern: variant.pattern,
 		declarations,
 		mode: "parts",
+		locale: message.locale,
 	});
 	const localVariablesCode = compiledLocalVariables.length
 		? compiledLocalVariables.join("\n\t") + "\n\t"
@@ -134,12 +136,14 @@ function compileMessageWithMultipleVariants(
 		const compiledPattern = compilePattern({
 			pattern: variant.pattern,
 			declarations,
+			locale: message.locale,
 		});
 		const compiledPartsPattern = hasMarkup
 			? compilePattern({
 					pattern: variant.pattern,
 					declarations,
 					mode: "parts",
+					locale: message.locale,
 				})
 			: undefined;
 

--- a/src/compiler/compile-pattern.test.ts
+++ b/src/compiler/compile-pattern.test.ts
@@ -125,6 +125,139 @@ test("plain string mode strips markup wrappers", () => {
 	expect(code).toBe("`Hello ${i?.name}!`");
 });
 
+test("compiles a pattern expression annotation to a registry call", () => {
+	// https://github.com/opral/paraglide-js/issues/694
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "count" },
+			annotation: { type: "function-reference", name: "number", options: [] },
+		},
+		{ type: "text", value: " views" },
+	];
+
+	const { code } = compilePattern({
+		pattern,
+		declarations: [{ type: "input-variable", name: "count" }],
+		locale: "en",
+	});
+
+	expect(code).toBe('`${registry.number("en", i?.count, {})} views`');
+});
+
+test("compiles pattern expression annotation options like local variable annotations", () => {
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "price" },
+			annotation: {
+				type: "function-reference",
+				name: "number",
+				options: [
+					{
+						name: "minimumFractionDigits",
+						value: { type: "literal", value: "2" },
+					},
+					{ name: "style", value: { type: "literal", value: "percent" } },
+				],
+			},
+		},
+	];
+
+	const { code } = compilePattern({
+		pattern,
+		declarations: [{ type: "input-variable", name: "price" }],
+		locale: "de",
+	});
+
+	expect(code).toBe(
+		'`${registry.number("de", i?.price, { minimumFractionDigits: 2, style: "percent" })}`'
+	);
+});
+
+test("parts mode compiles pattern expression annotations to registry calls", () => {
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "count" },
+			annotation: { type: "function-reference", name: "number", options: [] },
+		},
+		{ type: "text", value: " views" },
+	];
+
+	const { code } = compilePattern({
+		mode: "parts",
+		pattern,
+		declarations: [{ type: "input-variable", name: "count" }],
+		locale: "en",
+	});
+
+	expect(code).toBe(
+		'[{ type: "text", value: String(registry.number("en", i?.count, {})) }, { type: "text", value: " views" }]'
+	);
+});
+
+test("falls back to plain interpolation for unknown formatters", () => {
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "name" },
+			annotation: {
+				type: "function-reference",
+				name: "uppercase",
+				options: [],
+			},
+		},
+	];
+
+	const { code } = compilePattern({
+		pattern,
+		declarations: [{ type: "input-variable", name: "name" }],
+		locale: "en",
+	});
+
+	expect(code).toBe("`${i?.name}`");
+});
+
+test("throws when a pattern annotation is compiled without a locale", () => {
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "count" },
+			annotation: { type: "function-reference", name: "number", options: [] },
+		},
+	];
+
+	expect(() =>
+		compilePattern({
+			pattern,
+			declarations: [{ type: "input-variable", name: "count" }],
+		})
+	).toThrow('requires a locale to compile the formatter "number"');
+});
+
+test("validates relativetime options on pattern annotations", () => {
+	const pattern: Pattern = [
+		{
+			type: "expression",
+			arg: { type: "variable-reference", name: "days" },
+			annotation: {
+				type: "function-reference",
+				name: "relativetime",
+				options: [],
+			},
+		},
+	];
+
+	expect(() =>
+		compilePattern({
+			pattern,
+			declarations: [{ type: "input-variable", name: "days" }],
+			locale: "en",
+		})
+	).toThrow('The "relativetime" formatter requires a "unit" option.');
+});
+
 test("parts mode compiles text, markup, options and attributes", () => {
 	const pattern: Pattern = [
 		{ type: "text", value: "Read " },

--- a/src/compiler/compile-pattern.ts
+++ b/src/compiler/compile-pattern.ts
@@ -9,6 +9,12 @@ import type {
 import type { Compiled } from "./types.js";
 import { escapeForTemplateLiteral } from "../services/codegen/escape.js";
 import { compileInputAccess } from "./variable-access.js";
+import {
+	compileAnnotation,
+	isRegistryFunction,
+	registryFunctionNamesForDisplay,
+} from "./compile-annotation.js";
+import { Logger } from "../services/logger/index.js";
 
 export type CompilePatternMode = "string" | "parts";
 
@@ -29,6 +35,14 @@ export const compilePattern = (args: {
 	pattern: Pattern;
 	declarations: Declaration[];
 	mode?: CompilePatternMode;
+	/**
+	 * The locale of the message the pattern belongs to.
+	 *
+	 * Required to compile expressions with annotations like
+	 * `{ annotation: { type: "function-reference", name: "number" } }`
+	 * into `registry.number(locale, ...)` calls.
+	 */
+	locale?: string;
 }): Compiled<Pattern> => {
 	const mode = args.mode ?? "string";
 
@@ -42,6 +56,7 @@ export const compilePattern = (args: {
 function compilePatternToString(args: {
 	pattern: Pattern;
 	declarations: Declaration[];
+	locale?: string;
 }): Compiled<Pattern> {
 	let result = "";
 
@@ -51,7 +66,7 @@ function compilePatternToString(args: {
 				result += escapeForTemplateLiteral(part.value);
 				break;
 			case "expression":
-				result += `\${${compileExpressionValue(part, args.declarations)}}`;
+				result += `\${${compileExpression(part, args.declarations, args.locale)}}`;
 				break;
 			case "markup-start":
 			case "markup-end":
@@ -70,6 +85,7 @@ function compilePatternToString(args: {
 function compilePatternToParts(args: {
 	pattern: Pattern;
 	declarations: Declaration[];
+	locale?: string;
 }): Compiled<Pattern> {
 	const compiledParts: string[] = [];
 
@@ -82,9 +98,10 @@ function compilePatternToParts(args: {
 				break;
 			case "expression":
 				compiledParts.push(
-					`{ type: "text", value: String(${compileExpressionValue(
+					`{ type: "text", value: String(${compileExpression(
 						part,
-						args.declarations
+						args.declarations,
+						args.locale
 					)}) }`
 				);
 				break;
@@ -107,6 +124,55 @@ function compilePatternToParts(args: {
 		code: `[${compiledParts.join(", ")}]`,
 		node: args.pattern,
 	};
+}
+
+const logger = new Logger();
+
+/**
+ * Tracks annotation names that have already been warned about to avoid
+ * spamming the console when the same unsupported formatter is used in
+ * many messages (or across watch-mode recompiles).
+ */
+const warnedUnsupportedAnnotations = new Set<string>();
+
+/**
+ * Compiles a pattern expression including its annotation (if any).
+ *
+ * Annotations referencing a registry function compile to a `registry.*`
+ * call, identical to annotations on local variable declarations. Unknown
+ * annotations fall back to plain interpolation with a warning to avoid
+ * breaking compilation of messages imported from other i18n libraries
+ * (e.g. i18next's `{{value, customFormat}}`).
+ */
+function compileExpression(
+	expression: Expression,
+	declarations: Declaration[],
+	locale?: string
+): string {
+	const value = compileExpressionValue(expression, declarations);
+	const annotation = expression.annotation;
+
+	if (!annotation) {
+		return value;
+	}
+
+	if (!isRegistryFunction(annotation.name)) {
+		if (!warnedUnsupportedAnnotations.has(annotation.name)) {
+			warnedUnsupportedAnnotations.add(annotation.name);
+			logger.warn(
+				`The formatter "${annotation.name}" is unknown and will be ignored. The value is interpolated without formatting. Supported formatters: ${registryFunctionNamesForDisplay()}.`
+			);
+		}
+		return value;
+	}
+
+	if (locale === undefined) {
+		throw new Error(
+			`compilePattern() requires a locale to compile the formatter "${annotation.name}".`
+		);
+	}
+
+	return compileAnnotation(value, locale, annotation);
 }
 
 function compileExpressionValue(

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -1359,6 +1359,88 @@ describe.each([
 			expect(diagnostics.length).toEqual(0);
 		});
 
+		test("#694: pattern-level annotations compile to registry calls and pass checkJs", async () => {
+			const projectWithPatternAnnotation = await loadProjectInMemory({
+				blob: await newProject({
+					settings: {
+						baseLocale: "en",
+						locales: ["en"],
+					},
+				}),
+			});
+
+			await insertBundleNested(
+				projectWithPatternAnnotation.db,
+				createBundleNested({
+					id: "views",
+					declarations: [
+						{
+							type: "input-variable",
+							name: "count",
+						},
+					],
+					messages: [
+						{
+							locale: "en",
+							variants: [
+								{
+									pattern: [
+										{
+											type: "expression",
+											arg: { type: "variable-reference", name: "count" },
+											annotation: {
+												type: "function-reference",
+												name: "number",
+												options: [
+													{
+														name: "maximumFractionDigits",
+														value: { type: "literal", value: "1" },
+													},
+												],
+											},
+										},
+										{ type: "text", value: " views" },
+									],
+								},
+							],
+						},
+					],
+				})
+			);
+
+			const output = await compileProject({
+				project: projectWithPatternAnnotation,
+				compilerOptions,
+			});
+
+			expect(Object.values(output).join("\n")).toContain(
+				'registry.number("en", i?.count, { maximumFractionDigits: 1 })'
+			);
+
+			const tsProject = await typescriptProject({
+				useInMemoryFileSystem: true,
+				compilerOptions: superStrictRuleOutAnyErrorTsSettings,
+			});
+
+			for (const [fileName, code] of Object.entries(output)) {
+				if (fileName.endsWith(".js") || fileName.endsWith(".ts")) {
+					tsProject.createSourceFile(fileName, code);
+				}
+			}
+
+			const program = tsProject.createProgram();
+			const diagnostics = ts.getPreEmitDiagnostics(program).filter((d) => {
+				return !d.messageText
+					.toString()
+					.includes("Cannot find module 'async_hooks'");
+			});
+
+			for (const diagnostic of diagnostics) {
+				console.error(diagnostic.messageText, diagnostic.file?.fileName);
+			}
+			expect(diagnostics.length).toEqual(0);
+		});
+
 		test("relativetime formatter options should pass checkJs", async () => {
 			const projectWithRelativeTimeOptions = await loadProjectInMemory({
 				blob: await newProject({


### PR DESCRIPTION
Fixes #694

## Problem

i18next format options like `{{count, number}}` are imported by plugin-i18next as a pattern expression with a `function-reference` annotation. The compiler never read the `annotation` field on pattern expressions (`compileExpressionValue` took only `Pick<Expression, "arg">`), so it emitted plain interpolation and values rendered unformatted at runtime — silently, with exit code 0. The identical annotation shape on local-variable declarations already compiled correctly to `registry.*` calls.

```js
// before
const en_views = (i) => `${i?.count} views`        // "1234567.891 views"
// after
const en_views = (i) => `${registry.number("en", i?.count, {})} views`  // "1,234,567.891 views"
```

## Changes

- **New `src/compiler/compile-annotation.ts`** — the annotation-to-registry codegen (options compilation, numeric/boolean option tables, relativetime `unit` validation) extracted from `compile-local-variable.ts` into a shared module so pattern and local-variable annotations behave identically. Local-variable output is unchanged.
- **`compile-pattern.ts`** — pattern expressions now compile their annotation to a `registry.*` call in both string and parts modes. `compilePattern()` gained an optional `locale` parameter (public API, so optional for back-compat; throws a clear error if an annotation needs it and it's missing). `compile-message.ts` passes `message.locale` at all four call sites. The registry import in generated files already triggers on any `registry.` usage, so no output-structure changes were needed.
- **Unknown formatters warn instead of silently dropping or hard-failing.** Known registry formatters (`plural`, `number`, `datetime`, `relativetime`) always compile through the registry. Unknown names keep plain interpolation and emit a `[paraglide-js]` warning (deduped per formatter name). plugin-i18next passes any format name through verbatim (e.g. `{{name, uppercase}}`), so a hard compile error would block real i18next migrations — this covers both halves of the issue's expected behavior instead.

## Tests

- End-to-end test executing the compiled message: `views({ count: 1234567.891 })` → `"1,234,567.891 views"` (the exact issue reproduction)
- Unit tests for string mode, parts mode, option compilation (numeric literals like `minimumFractionDigits: 2`), multi-variant messages, unknown-formatter fallback, missing-locale error, and relativetime validation on patterns
- Project-level test compiling a full project with a pattern-level annotation under both output structures (`message-modules` and `locale-modules`), verifying the generated code passes super-strict checkJs

## Reviewer notes

- Local variables with unknown annotation names still blindly emit `registry.X(...)` (pre-existing behavior, pinned by tests anticipating custom registries). The pattern path is more forgiving by design — see the comment on `compileExpression`.
- Includes a `minor` changeset (new public `compilePattern` parameter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message/pattern code generation and adds a public compilePattern parameter; behavior change for i18next-style imports but covered by broad tests and graceful unknown-formatter fallback.
> 
> **Overview**
> Fixes **#694** by compiling **function-reference annotations on pattern expressions** (e.g. i18next `{{count, number}}`) into the same `registry.*` calls local-variable annotations already used, instead of dropping them as plain interpolation.
> 
> Annotation codegen is **extracted** to `compile-annotation.ts` and shared by `compile-local-variable.ts` and `compile-pattern.ts`. `compilePattern()` gains an optional **`locale`** argument (required when a known registry formatter is present); `compile-message.ts` passes `message.locale` at all pattern compile sites. **String and parts** modes both wrap annotated expressions through the registry. **Unknown** formatter names keep plain interpolation and emit a **deduped compile-time warning** rather than failing silently or erroring.
> 
> Adds unit, message-level, and full-project **checkJs** tests plus a **minor** changeset for the public `compilePattern` API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a8942beff6c3c570769c322d26ad5e9b1ee072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->