### PR TITLE
perf(bundler-plugins): skip recompilation when inputs unchanged across environments

### DIFF
--- a/.changeset/skip-recompile-per-environment.md
+++ b/.changeset/skip-recompile-per-environment.md
@@ -1,0 +1,25 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Skip recompilation when inputs are unchanged across bundler runs in the same process
+
+`vite build` fires `buildStart` once per environment (client, ssr, ...) and each run did a full `compile()` — project loading and message compilation — even though the inputs hadn't changed. The plugin now hashes the tracked input files, their directory listings, and the output-affecting options after a successful compile, and skips `compile()` entirely when the digest matches on the next run. The second and later environments become near-free:
+
+```
+vite v6.4.1 building for production...
+✔ [paraglide-js] Compilation complete (locale-modules)
+✓ built in 634ms
+vite v6.4.1 building SSR bundle for production...
+ℹ [paraglide-js] Compilation skipped — inputs unchanged (locale-modules)
+✓ built in 15ms
+```
+
+The digest fails open: any state it can't certify (missing files, read errors, changed options, a failed compile) forces a recompile. Multi-compiler webpack setups (client + server) benefit the same way via `beforeRun`.
+
+Also fixed along the way:
+
+- A user-provided `fs` option silently bypassed the plugin's file-read tracking (the args spread overrode the tracked fs wrapper), which left file watching inert for custom-fs setups.
+- The watch-target filter ignored any path *containing* the substring "cache" — a project under e.g. `/cachet-app/` had its inputs excluded from file watching. It now matches whole path segments only.
+
+Fixes https://github.com/opral/paraglide-js/issues/693

--- a/src/bundler-plugins/unplugin.test.ts
+++ b/src/bundler-plugins/unplugin.test.ts
@@ -1,5 +1,4 @@
 import { test, expect, beforeEach, afterEach, vi } from "vitest";
-import { paraglideVitePlugin } from "../bundler-plugins/vite.js";
 import consola from "consola";
 import { memfs } from "memfs";
 import {
@@ -30,6 +29,10 @@ afterEach(() => {
 });
 
 test("vite plugin does not throw when compilation is successful", async () => {
+	// Dynamic import so beforeEach's vi.resetModules() yields a fresh module
+	// (a static import would share module state across tests).
+	const { paraglideVitePlugin } = await import("../bundler-plugins/vite.js");
+
 	// Create and save a viable project to the virtual file system
 	const project = await loadProjectInMemory({
 		blob: await newProject({
@@ -62,6 +65,8 @@ test("vite plugin does not throw when compilation is successful", async () => {
 });
 
 test("vite plugin does not throw on compilation errors in development", async () => {
+	const { paraglideVitePlugin } = await import("../bundler-plugins/vite.js");
+
 	process.env.NODE_ENV = "development";
 
 	// Use memfs with no project (simulates missing project)
@@ -82,6 +87,8 @@ test("vite plugin does not throw on compilation errors in development", async ()
 });
 
 test("vite plugin throws on compilation errors at build time", async () => {
+	const { paraglideVitePlugin } = await import("../bundler-plugins/vite.js");
+
 	process.env.NODE_ENV = "production";
 
 	// Use memfs with no project (simulates missing project)
@@ -199,4 +206,232 @@ test("vite plugin warm-restart writes nothing when inputs unchanged (#659)", asy
 	await plugin2.buildStart?.call(mockContext);
 
 	expect(writeFileSpy).not.toHaveBeenCalled();
+});
+
+// Regression test for https://github.com/opral/paraglide-js/issues/693:
+// `vite build` fires buildStart once per environment (client, ssr) and each
+// run used to do a full compile() — project loading + message compilation —
+// even though the inputs hadn't changed.
+test("vite plugin skips compile() when buildStart fires again with unchanged inputs (#693)", async () => {
+	const actualCompileModule = await vi.importActual<
+		typeof import("../compiler/compile.js")
+	>("../compiler/compile.js");
+	const compileSpy = vi.fn(actualCompileModule.compile);
+	vi.doMock("../compiler/compile.js", () => ({
+		...actualCompileModule,
+		compile: compileSpy,
+	}));
+
+	try {
+		const { paraglideVitePlugin: vitePlugin } =
+			await import("../bundler-plugins/vite.js");
+
+		const project = await loadProjectInMemory({
+			blob: await newProject({
+				settings: {
+					baseLocale: "en",
+					locales: ["en", "de", "fr"],
+				},
+			}),
+		});
+
+		const fs = memfs().fs as unknown as typeof import("node:fs");
+
+		await saveProjectToDirectory({
+			project,
+			path: "/project.inlang",
+			fs: fs.promises,
+		});
+
+		const plugin = vitePlugin({
+			project: "/project.inlang",
+			outdir: "/test-output",
+			fs: fs,
+		}) as any;
+
+		const mockContext = { addWatchFile: () => {} };
+
+		// First environment (e.g. client) compiles.
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(1);
+
+		// Second environment (e.g. ssr) — inputs unchanged, compile skipped.
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(1);
+
+		// Changing an input file invalidates the digest and recompiles.
+		const settingsPath = "/project.inlang/settings.json";
+		const settings = JSON.parse(
+			await fs.promises.readFile(settingsPath, "utf-8")
+		);
+		settings.locales = ["en", "de", "fr", "es"];
+		await fs.promises.writeFile(settingsPath, JSON.stringify(settings));
+
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(2);
+	} finally {
+		vi.doUnmock("../compiler/compile.js");
+	}
+});
+
+// A new file added next to tracked inputs must invalidate the digest via
+// the directory-listing part of the hash, not only edits to known files.
+test("vite plugin recompiles when a file is added to a tracked directory (#693)", async () => {
+	const actualCompileModule = await vi.importActual<
+		typeof import("../compiler/compile.js")
+	>("../compiler/compile.js");
+	const compileSpy = vi.fn(actualCompileModule.compile);
+	vi.doMock("../compiler/compile.js", () => ({
+		...actualCompileModule,
+		compile: compileSpy,
+	}));
+
+	try {
+		const { paraglideVitePlugin: vitePlugin } =
+			await import("../bundler-plugins/vite.js");
+
+		const project = await loadProjectInMemory({
+			blob: await newProject({
+				settings: { baseLocale: "en", locales: ["en", "de"] },
+			}),
+		});
+
+		const fs = memfs().fs as unknown as typeof import("node:fs");
+
+		await saveProjectToDirectory({
+			project,
+			path: "/project.inlang",
+			fs: fs.promises,
+		});
+
+		const plugin = vitePlugin({
+			project: "/project.inlang",
+			outdir: "/test-output",
+			fs: fs,
+		}) as any;
+
+		const mockContext = { addWatchFile: () => {} };
+
+		await plugin.buildStart?.call(mockContext);
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(1);
+
+		// No tracked file changed, but the listing of a tracked directory did.
+		await fs.promises.writeFile("/project.inlang/added-later.txt", "new");
+
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(2);
+	} finally {
+		vi.doUnmock("../compiler/compile.js");
+	}
+});
+
+// After a failed compile the stored digest must not be reused: restoring an
+// input to its previous content has to trigger a real recompile, because the
+// failed attempt may have left no (or partial) output.
+test("vite plugin does not reuse a digest from before a failed compile (#693)", async () => {
+	process.env.NODE_ENV = "development";
+
+	const actualCompileModule = await vi.importActual<
+		typeof import("../compiler/compile.js")
+	>("../compiler/compile.js");
+	const compileSpy = vi.fn(actualCompileModule.compile);
+	vi.doMock("../compiler/compile.js", () => ({
+		...actualCompileModule,
+		compile: compileSpy,
+	}));
+
+	try {
+		const { paraglideVitePlugin: vitePlugin } =
+			await import("../bundler-plugins/vite.js");
+
+		const project = await loadProjectInMemory({
+			blob: await newProject({
+				settings: { baseLocale: "en", locales: ["en", "de"] },
+			}),
+		});
+
+		const fs = memfs().fs as unknown as typeof import("node:fs");
+
+		await saveProjectToDirectory({
+			project,
+			path: "/project.inlang",
+			fs: fs.promises,
+		});
+
+		const plugin = vitePlugin({
+			project: "/project.inlang",
+			outdir: "/test-output",
+			fs: fs,
+		}) as any;
+
+		const mockContext = { addWatchFile: () => {} };
+
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(1);
+
+		const settingsPath = "/project.inlang/settings.json";
+		const originalSettings = await fs.promises.readFile(settingsPath, "utf-8");
+
+		// Break the settings file — the compile attempt fails (dev mode
+		// swallows the error) and must clear the stored digest.
+		await fs.promises.writeFile(settingsPath, "{ not json");
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(2);
+
+		// Restore the exact original content. The digest now matches the one
+		// from before the failure — it must have been cleared, so this
+		// buildStart has to compile again instead of skipping.
+		await fs.promises.writeFile(settingsPath, originalSettings);
+		await plugin.buildStart?.call(mockContext);
+		expect(compileSpy).toHaveBeenCalledTimes(3);
+	} finally {
+		vi.doUnmock("../compiler/compile.js");
+	}
+});
+
+// Two plugin instances with different filesystems must not share the tracked
+// fs wrapper or cached compilation state — each compiles into its own fs.
+test("vite plugin instances with different fs compile against their own fs (#693)", async () => {
+	const { paraglideVitePlugin: vitePlugin } =
+		await import("../bundler-plugins/vite.js");
+
+	const makeProjectFs = async () => {
+		const project = await loadProjectInMemory({
+			blob: await newProject({
+				settings: { baseLocale: "en", locales: ["en"] },
+			}),
+		});
+		const fs = memfs().fs as unknown as typeof import("node:fs");
+		await saveProjectToDirectory({
+			project,
+			path: "/project.inlang",
+			fs: fs.promises,
+		});
+		return fs;
+	};
+
+	const fsA = await makeProjectFs();
+	const fsB = await makeProjectFs();
+
+	const mockContext = { addWatchFile: () => {} };
+
+	const pluginA = vitePlugin({
+		project: "/project.inlang",
+		outdir: "/test-output",
+		fs: fsA,
+	}) as any;
+	await pluginA.buildStart?.call(mockContext);
+
+	const pluginB = vitePlugin({
+		project: "/project.inlang",
+		outdir: "/test-output",
+		fs: fsB,
+	}) as any;
+	await pluginB.buildStart?.call(mockContext);
+
+	// B's output must exist in B's filesystem — with a shared tracked fs it
+	// would have been read from and written into A's filesystem instead.
+	const outputB = await fsB.promises.readdir("/test-output");
+	expect(outputB.length).toBeGreaterThan(0);
 });

--- a/src/bundler-plugins/unplugin.ts
+++ b/src/bundler-plugins/unplugin.ts
@@ -1,6 +1,8 @@
 import type { UnpluginFactory } from "unplugin";
 import { compile, type CompilationResult } from "../compiler/compile.js";
 import { relative } from "node:path";
+import { createHash } from "node:crypto";
+import nodeFs from "node:fs";
 import { Logger } from "../services/logger/index.js";
 import type { CompilerOptions } from "../compiler/compiler-options.js";
 import {
@@ -20,8 +22,46 @@ const logger = new Logger();
  */
 let isServer: string | undefined;
 
-let previousCompilation: CompilationResult | undefined;
-const { fs: trackedFs, readFiles, clearReadFiles } = createTrackedFs();
+type PluginState = {
+	/** Identity of the fs the tracked wrapper was created around. */
+	baseFs: typeof nodeFs | undefined;
+	trackedFs: typeof nodeFs;
+	readFiles: Set<string>;
+	clearReadFiles: () => void;
+	previousCompilation: CompilationResult | undefined;
+	/**
+	 * Digest of the input files and options of the last successful compilation.
+	 *
+	 * `vite build` fires `buildStart` once per environment (client, ssr, ...).
+	 * When the digest of the current inputs matches, `compile()` is skipped
+	 * entirely — project loading and message compilation are expensive even
+	 * when `previousCompilation` dedupes the writes.
+	 *
+	 * https://github.com/opral/paraglide-js/issues/693
+	 */
+	previousInputsDigest: string | undefined;
+};
+
+// Module-scoped so the warm state survives plugin re-instantiation within
+// one process (e.g. a vite config reload), but recreated when a different
+// fs is passed — the tracked wrapper, read set, and cached compilation are
+// only valid for the filesystem they were produced from.
+let pluginState: PluginState | undefined;
+
+function getPluginState(args: CompilerOptions): PluginState {
+	if (pluginState === undefined || pluginState.baseFs !== args.fs) {
+		const tracked = createTrackedFs({ fs: args.fs });
+		pluginState = {
+			baseFs: args.fs,
+			trackedFs: tracked.fs,
+			readFiles: tracked.readFiles,
+			clearReadFiles: tracked.clearReadFiles,
+			previousCompilation: undefined,
+			previousInputsDigest: undefined,
+		};
+	}
+	return pluginState;
+}
 
 function withoutCleanOutdir(
 	args: CompilerOptions
@@ -31,133 +71,88 @@ function withoutCleanOutdir(
 	return compileArgs;
 }
 
-export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
-	name: PLUGIN_NAME,
-	enforce: "pre",
-	async buildStart() {
-		const isProduction = process.env.NODE_ENV === "production";
-		// default to locale-modules for development to speed up the dev server
-		// https://github.com/opral/inlang-paraglide-js/issues/486
-		const outputStructure =
-			args.outputStructure ??
-			(isProduction ? "message-modules" : "locale-modules");
-		try {
-			// On a fresh process, seed previousCompilation from on-disk hashes
-			// so the first compile is a no-op when inputs are unchanged. Avoids
-			// racing concurrent readers that wiping outdir would interrupt.
-			const seededPrevious =
-				previousCompilation ??
-				(await seedPreviousCompilationFromOutdir({
-					outdir: args.outdir,
-					fs: args.fs?.promises,
-				}));
-			previousCompilation = await compile({
-				fs: trackedFs,
-				previousCompilation: seededPrevious,
-				outputStructure,
-				isServer,
-				...withoutCleanOutdir(args),
-				cleanOutdir: false,
-			});
-			logger.success(`Compilation complete (${outputStructure})`);
-		} catch (error) {
-			logger.error("Failed to compile project:", (error as Error).message);
-			logger.info("Please check your translation files for syntax errors.");
-			if (isProduction) throw error;
-		} finally {
-			// in any case add the files to watch
-			const targets = getWatchTargets(readFiles, { outdir: args.outdir });
-			for (const filePath of targets.files) {
-				this.addWatchFile(filePath);
-			}
-			for (const directoryPath of targets.directories) {
-				this.addWatchFile(directoryPath);
+/**
+ * Hashes the files (and directory listings) the last compilation read,
+ * together with the options that affect the output. Returns `undefined`
+ * when the digest can't be computed (no tracked reads yet, an unexpected
+ * read error, ...) — `undefined` never matches, so the caller compiles.
+ *
+ * Directory listings are included so that a message file *added* next to
+ * the tracked ones invalidates the digest, not only edits to known files.
+ * All components are length-prefixed so distinct input states can't
+ * produce the same hash stream.
+ *
+ * The digest is taken after the compile, by re-reading the inputs. A file
+ * edited *during* a compile can therefore be hashed at its new content
+ * while the output reflects the old one — accepted: in dev, watchChange
+ * recompiles on that edit, and a fresh build process always recompiles.
+ */
+async function computeInputsDigest(
+	state: PluginState,
+	args: CompilerOptions,
+	outputStructure: NonNullable<CompilerOptions["outputStructure"]>
+): Promise<string | undefined> {
+	if (state.readFiles.size === 0) {
+		return undefined;
+	}
+	const targets = getWatchTargets(state.readFiles, { outdir: args.outdir });
+	if (targets.files.size === 0) {
+		return undefined;
+	}
+	const fsp = (args.fs ?? nodeFs).promises;
+	const hash = createHash("sha256");
+	try {
+		const { fs: _fs, ...serializableArgs } = args;
+		void _fs;
+		hash.update(
+			JSON.stringify({ ...serializableArgs, outputStructure, isServer })
+		);
+		for (const directoryPath of [...targets.directories].sort()) {
+			const entries = await fsp
+				.readdir(directoryPath)
+				// tracked reads include probed-but-absent paths (the SDK reads
+				// optional files and handles ENOENT itself) — a missing entry
+				// is valid input state, hash it as such
+				.catch(rethrowUnlessEnoent);
+			hash.update(`\0dir:${directoryPath.length}:${directoryPath}:`);
+			if (entries === undefined) {
+				hash.update("missing");
+			} else {
+				for (const entry of [...entries].sort()) {
+					hash.update(`${entry.length}:${entry},`);
+				}
 			}
 		}
-	},
-	async watchChange(path) {
-		const normalizedPath = nodeNormalizePath(path);
-		const targets = getWatchTargets(readFiles, { outdir: args.outdir });
-		if (targets.isIgnoredPath(normalizedPath)) {
-			return;
-		}
-		const shouldCompile =
-			targets.files.has(normalizedPath) ||
-			isPathWithinDirectories(normalizedPath, targets.directories);
-		if (shouldCompile === false) {
-			return;
-		}
-
-		const isProduction = process.env.NODE_ENV === "production";
-
-		// default to locale-modules for development to speed up the dev server
-		// https://github.com/opral/inlang-paraglide-js/issues/486
-		const outputStructure =
-			args.outputStructure ??
-			(isProduction ? "message-modules" : "locale-modules");
-
-		const previouslyReadFiles = new Set(readFiles);
-
-		try {
-			logger.info(
-				`Re-compiling inlang project... File "${relative(process.cwd(), path)}" has changed.`
-			);
-
-			// Clear readFiles to track fresh file reads
-			clearReadFiles();
-
-			previousCompilation = await compile({
-				fs: trackedFs,
-				previousCompilation,
-				outputStructure,
-				isServer,
-				...withoutCleanOutdir(args),
-				cleanOutdir: false,
-			});
-
-			logger.success(`Re-compilation complete (${outputStructure})`);
-
-			// Add any new files to watch
-			const nextTargets = getWatchTargets(readFiles, { outdir: args.outdir });
-			for (const filePath of nextTargets.files) {
-				this.addWatchFile(filePath);
+		for (const filePath of [...targets.files].sort()) {
+			const content = await fsp.readFile(filePath).catch(rethrowUnlessEnoent);
+			hash.update(`\0file:${filePath.length}:${filePath}:`);
+			if (content === undefined) {
+				hash.update("missing");
+			} else {
+				hash.update(`${content.length}:`);
+				hash.update(content);
 			}
-			for (const directoryPath of nextTargets.directories) {
-				this.addWatchFile(directoryPath);
-			}
-		} catch (e) {
-			clearReadFiles();
-			for (const filePath of previouslyReadFiles) {
-				readFiles.add(filePath);
-			}
-			// Reset compilation result on error
-			previousCompilation = undefined;
-			logger.warn("Failed to re-compile project:", (e as Error).message);
 		}
-	},
-	vite: {
-		config: {
-			handler: () => {
-				isServer = "import.meta.env?.SSR ?? typeof window === 'undefined'";
-			},
-		},
-		configEnvironment: {
-			handler: () => {
-				isServer = "import.meta.env?.SSR ?? typeof window === 'undefined'";
-			},
-		},
-	},
-	webpack(compiler) {
-		compiler.options.resolve = {
-			...compiler.options.resolve,
-			fallback: {
-				...compiler.options.resolve?.fallback,
-				// https://stackoverflow.com/a/72989932
-				async_hooks: false,
-			},
-		};
+	} catch {
+		return undefined;
+	}
+	return hash.digest("hex");
+}
 
-		compiler.hooks.beforeRun.tapPromise(PLUGIN_NAME, async () => {
+function rethrowUnlessEnoent(error: unknown): undefined {
+	if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+		return undefined;
+	}
+	throw error;
+}
+
+export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => {
+	const state = getPluginState(args);
+	const { trackedFs, readFiles, clearReadFiles } = state;
+	return {
+		name: PLUGIN_NAME,
+		enforce: "pre",
+		async buildStart() {
 			const isProduction = process.env.NODE_ENV === "production";
 			// default to locale-modules for development to speed up the dev server
 			// https://github.com/opral/inlang-paraglide-js/issues/486
@@ -165,25 +160,199 @@ export const unpluginFactory: UnpluginFactory<CompilerOptions> = (args) => ({
 				args.outputStructure ??
 				(isProduction ? "message-modules" : "locale-modules");
 			try {
+				// `vite build` calls buildStart once per environment (client, ssr).
+				// Skip the expensive compile when the inputs haven't changed.
+				if (state.previousCompilation && state.previousInputsDigest) {
+					const currentDigest = await computeInputsDigest(
+						state,
+						args,
+						outputStructure
+					);
+					if (currentDigest === state.previousInputsDigest) {
+						logger.info(
+							`Compilation skipped — inputs unchanged (${outputStructure})`
+						);
+						return;
+					}
+				}
+				// On a fresh process, seed previousCompilation from on-disk hashes
+				// so the first compile is a no-op when inputs are unchanged. Avoids
+				// racing concurrent readers that wiping outdir would interrupt.
 				const seededPrevious =
-					previousCompilation ??
+					state.previousCompilation ??
 					(await seedPreviousCompilationFromOutdir({
 						outdir: args.outdir,
 						fs: args.fs?.promises,
 					}));
-				previousCompilation = await compile({
-					fs: trackedFs,
+				state.previousCompilation = await compile({
 					previousCompilation: seededPrevious,
 					outputStructure,
+					isServer,
 					...withoutCleanOutdir(args),
 					cleanOutdir: false,
+					// after the args spread so a user-provided fs doesn't bypass
+					// the read tracking (trackedFs wraps args.fs when provided)
+					fs: trackedFs,
 				});
+				state.previousInputsDigest = await computeInputsDigest(
+					state,
+					args,
+					outputStructure
+				);
 				logger.success(`Compilation complete (${outputStructure})`);
 			} catch (error) {
-				logger.warn("Failed to compile project:", (error as Error).message);
-				logger.warn("Please check your translation files for syntax errors.");
+				state.previousInputsDigest = undefined;
+				logger.error("Failed to compile project:", (error as Error).message);
+				logger.info("Please check your translation files for syntax errors.");
 				if (isProduction) throw error;
+			} finally {
+				// in any case add the files to watch
+				const targets = getWatchTargets(readFiles, { outdir: args.outdir });
+				for (const filePath of targets.files) {
+					this.addWatchFile(filePath);
+				}
+				for (const directoryPath of targets.directories) {
+					this.addWatchFile(directoryPath);
+				}
 			}
-		});
-	},
-});
+		},
+		async watchChange(path) {
+			const normalizedPath = nodeNormalizePath(path);
+			const targets = getWatchTargets(readFiles, { outdir: args.outdir });
+			if (targets.isIgnoredPath(normalizedPath)) {
+				return;
+			}
+			const shouldCompile =
+				targets.files.has(normalizedPath) ||
+				isPathWithinDirectories(normalizedPath, targets.directories);
+			if (shouldCompile === false) {
+				return;
+			}
+
+			const isProduction = process.env.NODE_ENV === "production";
+
+			// default to locale-modules for development to speed up the dev server
+			// https://github.com/opral/inlang-paraglide-js/issues/486
+			const outputStructure =
+				args.outputStructure ??
+				(isProduction ? "message-modules" : "locale-modules");
+
+			const previouslyReadFiles = new Set(readFiles);
+
+			try {
+				logger.info(
+					`Re-compiling inlang project... File "${relative(process.cwd(), path)}" has changed.`
+				);
+
+				// Clear readFiles to track fresh file reads
+				clearReadFiles();
+
+				state.previousCompilation = await compile({
+					previousCompilation: state.previousCompilation,
+					outputStructure,
+					isServer,
+					...withoutCleanOutdir(args),
+					cleanOutdir: false,
+					fs: trackedFs,
+				});
+				state.previousInputsDigest = await computeInputsDigest(
+					state,
+					args,
+					outputStructure
+				);
+
+				logger.success(`Re-compilation complete (${outputStructure})`);
+
+				// Add any new files to watch
+				const nextTargets = getWatchTargets(readFiles, { outdir: args.outdir });
+				for (const filePath of nextTargets.files) {
+					this.addWatchFile(filePath);
+				}
+				for (const directoryPath of nextTargets.directories) {
+					this.addWatchFile(directoryPath);
+				}
+			} catch (e) {
+				clearReadFiles();
+				for (const filePath of previouslyReadFiles) {
+					readFiles.add(filePath);
+				}
+				// Reset compilation result on error
+				state.previousCompilation = undefined;
+				state.previousInputsDigest = undefined;
+				logger.warn("Failed to re-compile project:", (e as Error).message);
+			}
+		},
+		vite: {
+			config: {
+				handler: () => {
+					isServer = "import.meta.env?.SSR ?? typeof window === 'undefined'";
+				},
+			},
+			configEnvironment: {
+				handler: () => {
+					isServer = "import.meta.env?.SSR ?? typeof window === 'undefined'";
+				},
+			},
+		},
+		webpack(compiler) {
+			compiler.options.resolve = {
+				...compiler.options.resolve,
+				fallback: {
+					...compiler.options.resolve?.fallback,
+					// https://stackoverflow.com/a/72989932
+					async_hooks: false,
+				},
+			};
+
+			compiler.hooks.beforeRun.tapPromise(PLUGIN_NAME, async () => {
+				const isProduction = process.env.NODE_ENV === "production";
+				// default to locale-modules for development to speed up the dev server
+				// https://github.com/opral/inlang-paraglide-js/issues/486
+				const outputStructure =
+					args.outputStructure ??
+					(isProduction ? "message-modules" : "locale-modules");
+				try {
+					// Multi-compiler webpack setups (client + server) trigger
+					// beforeRun once per compiler — skip when inputs are unchanged.
+					if (state.previousCompilation && state.previousInputsDigest) {
+						const currentDigest = await computeInputsDigest(
+							state,
+							args,
+							outputStructure
+						);
+						if (currentDigest === state.previousInputsDigest) {
+							logger.info(
+								`Compilation skipped — inputs unchanged (${outputStructure})`
+							);
+							return;
+						}
+					}
+					const seededPrevious =
+						state.previousCompilation ??
+						(await seedPreviousCompilationFromOutdir({
+							outdir: args.outdir,
+							fs: args.fs?.promises,
+						}));
+					state.previousCompilation = await compile({
+						previousCompilation: seededPrevious,
+						outputStructure,
+						...withoutCleanOutdir(args),
+						cleanOutdir: false,
+						fs: trackedFs,
+					});
+					state.previousInputsDigest = await computeInputsDigest(
+						state,
+						args,
+						outputStructure
+					);
+					logger.success(`Compilation complete (${outputStructure})`);
+				} catch (error) {
+					state.previousInputsDigest = undefined;
+					logger.warn("Failed to compile project:", (error as Error).message);
+					logger.warn("Please check your translation files for syntax errors.");
+					if (isProduction) throw error;
+				}
+			});
+		},
+	};
+};

--- a/src/services/file-watching/tracked-fs.ts
+++ b/src/services/file-watching/tracked-fs.ts
@@ -58,7 +58,9 @@ export function getWatchTargets(
 
 	const isIgnoredPath = (path: string) => {
 		const normalizedPath = nodeNormalizePath(path);
-		if (ignoreCache && normalizedPath.includes("cache")) {
+		// match whole path segments only — a project under e.g. /cachet-app/
+		// must not have its inputs ignored
+		if (ignoreCache && /(^|\/)cache(\/|$)/.test(normalizedPath)) {
 			return true;
 		}
 		if (


### PR DESCRIPTION
Fixes #693

## Problem

When `vite build` builds more than one environment (e.g. `client` and `ssr`, as TanStack Start and the Cloudflare plugin set up), `buildStart` fires per environment and each run does a full `compile()` — project loading plus message compilation — even though the inputs haven't changed. `previousCompilation` (#659) dedupes the writes, but the expensive work still runs every time (~2.8s for the second environment on the reporter's project).

## Solution

After a successful compile, hash the tracked input files (the existing `createTrackedFs` read set, filtered through `getWatchTargets`), their **directory listings** (so an *added* message file invalidates, not only edits), and the output-affecting options (`outputStructure`, `isServer`, plugin args). On the next `buildStart` — or webpack `beforeRun` in multi-compiler setups — skip `compile()` entirely when the digest matches. Watch-file registration still runs on the skip path.

The digest **fails open**: anything it can't certify forces a recompile — unexpected read errors, changed options, a failed compile (clears the digest), no tracked reads yet. Files the SDK probes but that don't exist (e.g. `project.inlang/project_id`) hash as missing rather than aborting. All hash components are length-prefixed so distinct input states can't collide.

## Latent bugs fixed along the way

- **A user-provided `fs` bypassed read tracking entirely** — the args spread overrode `fs: trackedFs` in the compile call, leaving file watching inert for custom-fs setups. The tracked wrapper now wraps `args.fs` and wins the spread. Tracked state is keyed by fs identity so plugin instances with different filesystems don't share a wrapper or cached compilation.
- **The watch-target filter ignored any path *containing* "cache"** — a project under e.g. `/cachet-app/` had its inputs excluded from watching (and would have been excluded from the digest). It now matches whole path segments only; the SDK's actual cache paths (`project.inlang/cache/...`) are still ignored.

## Verification

- New regression tests: skip on unchanged inputs / recompile on edit, recompile when a file is **added** to a tracked directory, digest cleared after a failed compile (restoring the original content must still recompile), and per-fs state isolation. The main test was falsified in both directions (skip disabled → fails at the skip assertion; digest frozen → fails at the invalidation assertion).
- Three independent review passes over the change (correctness/wrong-skip hunting, regression analysis of the spread reordering across all three compile call sites and the #659 guarantees, test falsification); all confirmed findings addressed.
- Live smoke test on `examples/vite` with a temporary second (ssr) environment:

  ```
  vite v6.4.1 building for production...
  ✔ [paraglide-js] Compilation complete (locale-modules)
  ✓ built in 634ms
  vite v6.4.1 building SSR bundle for production...
  ℹ [paraglide-js] Compilation skipped — inputs unchanged (locale-modules)
  ✓ built in 15ms
  ```

  A sentinel message edit then propagated to **both** the client and ssr bundles on rebuild — the skip never serves stale content.

## Known limitation

The digest is in-memory, so a fresh build process still pays one full compile — the win is every environment/compiler run after the first within a process. An edit landing *during* a compile can hash at its new content (documented in code); dev mode self-heals via `watchChange` and a fresh build always recompiles — pre-fix, the same race produced client and ssr bundles with *different* message content within one build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when compilation runs and what invalidates it; incorrect skipping could serve stale locale output, though the digest is designed to fail open and tests cover main invalidation paths.
> 
> **Overview**
> Adds an **input digest** after each successful compile (tracked file contents, directory listings, and output-affecting options) so later `buildStart` / webpack `beforeRun` calls in the same process can **skip `compile()`** when nothing changed—addressing redundant work when Vite builds client and SSR (or multiple webpack compilers). The digest **fails open** (uncertain state, errors, or a failed compile clears it and forces a recompile).
> 
> Plugin state is now keyed by **filesystem identity**: the tracked `fs` wrapper wraps a user-provided `fs`, and `fs: trackedFs` is applied **after** the options spread so read tracking and watches work for custom-fs setups. Cached compilation/digest are not shared across different `fs` instances.
> 
> The watch-target **cache** filter now matches whole path segments only (so paths like `/cachet-app/` are not wrongly ignored).
> 
> Regression tests cover skip vs recompile on edit, new files in tracked dirs, post-failure digest invalidation, and per-`fs` isolation; Vite tests use dynamic imports so module state resets cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57efa1ec7bc8ac40c5cda16f9c7c38ba29d44c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->