### PR TITLE
chore: update @inlang/sdk to 2.10.0

### DIFF
--- a/.changeset/update-inlang-sdk-2-10-0.md
+++ b/.changeset/update-inlang-sdk-2-10-0.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Update `@inlang/sdk` to 2.10.0.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	},
 	"dependencies": {
 		"@inlang/recommend-sherlock": "^0.2.1",
-		"@inlang/sdk": "^2.9.3",
+		"@inlang/sdk": "^2.10.0",
 		"commander": "11.1.0",
 		"consola": "3.4.0",
 		"json5": "2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       '@inlang/sdk':
-        specifier: ^2.9.3
-        version: 2.9.3(babel-plugin-macros@3.1.0)
+        specifier: ^2.10.0
+        version: 2.10.0(babel-plugin-macros@3.1.0)
       commander:
         specifier: 11.1.0
         version: 11.1.0
@@ -1669,13 +1669,13 @@ packages:
   '@inlang/recommend-sherlock@0.2.1':
     resolution: {integrity: sha512-ckv8HvHy/iTqaVAEKrr+gnl+p3XFNwe5D2+6w6wJk2ORV2XkcRkKOJ/XsTUJbPSiyi4PI+p+T3bqbmNx/rDUlg==}
 
+  '@inlang/sdk@2.10.0':
+    resolution: {integrity: sha512-xLVRHAI9Jw6L/NrlK6s1mXCvbFwzk5INEL4i3By4jW9yjIMchJ+JGSw4WgFpiLlcoBuR/qIMmSn6te/Jozuybg==}
+    engines: {node: '>=20.0.0'}
+
   '@inlang/sdk@2.4.9':
     resolution: {integrity: sha512-cvz/C1rF5WBxzHbEoiBoI6Sz6q6M+TdxfWkEGBYTD77opY8i8WN01prUWXEM87GPF4SZcyIySez9U0Ccm12oFQ==}
     engines: {node: '>=18.0.0'}
-
-  '@inlang/sdk@2.9.3':
-    resolution: {integrity: sha512-E/SxcSji8WIt4DqQG9APlOs6tVtJxrrOUS3dE4ho3pWRCLLIY0PIVzgNwSukuFT+m8LuJDFwpRY5VY3ryzyGWQ==}
-    engines: {node: '>=20.0.0'}
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -8016,6 +8016,16 @@ snapshots:
     dependencies:
       comment-json: 4.5.1
 
+  '@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0)':
+    dependencies:
+      '@lix-js/sdk': 0.4.10(babel-plugin-macros@3.1.0)
+      '@sinclair/typebox': 0.31.28
+      kysely: 0.28.16
+      sqlite-wasm-kysely: 0.3.0(kysely@0.28.16)
+      uuid: 14.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+
   '@inlang/sdk@2.4.9(babel-plugin-macros@3.1.0)':
     dependencies:
       '@lix-js/sdk': 0.4.7(babel-plugin-macros@3.1.0)
@@ -8023,16 +8033,6 @@ snapshots:
       kysely: 0.27.6
       sqlite-wasm-kysely: 0.3.0(kysely@0.27.6)
       uuid: 10.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-
-  '@inlang/sdk@2.9.3(babel-plugin-macros@3.1.0)':
-    dependencies:
-      '@lix-js/sdk': 0.4.10(babel-plugin-macros@3.1.0)
-      '@sinclair/typebox': 0.31.28
-      kysely: 0.28.16
-      sqlite-wasm-kysely: 0.3.0(kysely@0.28.16)
-      uuid: 14.0.0
     transitivePeerDependencies:
       - babel-plugin-macros
 


### PR DESCRIPTION
## What changed

Upgrades `@inlang/sdk` from ^2.9.3 to ^2.10.0 and adds a patch changeset for `@inlang/paraglide-js`.

## Why

Keep the SDK dependency current with the latest release.

## Notes for reviewers

- Build (`pnpm run build`) and the full test suite (40 test files) pass with the new version.
- No code changes were required — only `package.json`, the lockfile, and the changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency upgrade with no code changes; transitive SDK stack updates are the main variable, mitigated if CI/build/tests already pass on 2.10.0.
> 
> **Overview**
> Bumps **`@inlang/sdk`** from `^2.9.3` to **`^2.10.0`** in the root `package.json` and refreshes **`pnpm-lock.yaml`**. The resolved SDK now pulls **`@lix-js/sdk` 0.4.10**, **`kysely` 0.28.16**, and **`uuid` 14.0.0** (replacing the versions that came with 2.9.3).
> 
> Adds a **patch changeset** for `@inlang/paraglide-js` documenting the SDK upgrade. **No application or compiler source changes** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601061147a0544e96fd381b62d7c75062f4b7d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->