### PR TITLE
feat: Emit messages/package.json with sideEffects: false for message-modules

### DIFF
--- a/.changeset/message-modules-side-effects.md
+++ b/.changeset/message-modules-side-effects.md
@@ -2,10 +2,10 @@
 "@inlang/paraglide-js": minor
 ---
 
-Emit `messages/package.json` with `{ "sideEffects": false }` for `message-modules` output, declaring the generated message modules side-effect-free.
+Emit `messages/package.json` with `{ "type": "module", "sideEffects": false }` for `message-modules` output, declaring the generated message modules side-effect-free.
 
 This lets bundlers (notably Vite 8 / Rolldown) drop unused re-exports from the `m` barrel per entry, instead of bundling every message used anywhere in the app into one shared chunk that every entry downloads. Without it, per-page JS scales with the union of all messages used across the app rather than with the messages a given route actually uses.
 
-The declaration is scoped to `messages/`, so `runtime.js` (which has real side effects) is unaffected.
+The declaration is scoped to `messages/`, so `runtime.js` (which has real side effects) is unaffected. `type: "module"` is included because the package.json creates a new module scope for `messages/`; without it, the generated ESM files would default to CommonJS (a package.json without `type` is CJS in Node, even when the consuming project is `type: "module"`).
 
 See https://github.com/opral/paraglide-js/issues/668

--- a/.changeset/message-modules-side-effects.md
+++ b/.changeset/message-modules-side-effects.md
@@ -1,0 +1,11 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Emit `messages/package.json` with `{ "sideEffects": false }` for `message-modules` output, declaring the generated message modules side-effect-free.
+
+This lets bundlers (notably Vite 8 / Rolldown) drop unused re-exports from the `m` barrel per entry, instead of bundling every message used anywhere in the app into one shared chunk that every entry downloads. Without it, per-page JS scales with the union of all messages used across the app rather than with the messages a given route actually uses.
+
+The declaration is scoped to `messages/`, so `runtime.js` (which has real side effects) is unaffected.
+
+See https://github.com/opral/paraglide-js/issues/668

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -94,9 +94,11 @@ test("emits messages/package.json with sideEffects:false for message-modules", a
 
 	// message-modules: the message modules are side-effect-free, so bundlers can
 	// drop unused re-exports from the `m` barrel per entry instead of emitting one
-	// shared chunk with every message.
+	// shared chunk with every message. `type: "module"` keeps the generated ESM
+	// files in the new `messages/` package scope from defaulting to CommonJS.
 	expect(messageModules).toHaveProperty("messages/package.json");
 	expect(JSON.parse(messageModules["messages/package.json"]!)).toEqual({
+		type: "module",
 		sideEffects: false,
 	});
 

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -73,6 +73,37 @@ test("emitGitignore", async () => {
 	expect(_false).not.toHaveProperty(".gitignore");
 });
 
+test("emits messages/package.json with sideEffects:false for message-modules", async () => {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				locales: ["en", "de"],
+				baseLocale: "en",
+			},
+		}),
+	});
+
+	const messageModules = await compileProject({
+		project,
+	});
+
+	const localeModules = await compileProject({
+		project,
+		compilerOptions: { outputStructure: "locale-modules" },
+	});
+
+	// message-modules: the message modules are side-effect-free, so bundlers can
+	// drop unused re-exports from the `m` barrel per entry instead of emitting one
+	// shared chunk with every message.
+	expect(messageModules).toHaveProperty("messages/package.json");
+	expect(JSON.parse(messageModules["messages/package.json"]!)).toEqual({
+		sideEffects: false,
+	});
+
+	// scoped to message-modules (the structure with the re-export barrel)
+	expect(localeModules).not.toHaveProperty("messages/package.json");
+});
+
 test("emitPrettierIgnore", async () => {
 	const project = await loadProjectInMemory({
 		blob: await newProject({

--- a/src/compiler/compile-project.ts
+++ b/src/compiler/compile-project.ts
@@ -101,6 +101,18 @@ export const compileProject = async (args: {
 		output["README.md"] = createReadme({ projectPath: args.projectPath });
 	}
 
+	// Declare the generated message modules side-effect-free so bundlers can drop
+	// unused re-exports from the `m` barrel per entry, instead of bundling every
+	// message used anywhere in the app into one shared chunk that every entry
+	// downloads. Scoped to `messages/` so `runtime.js` (one level up, which has
+	// real side effects) is unaffected. Only relevant for `message-modules`,
+	// the structure with the re-export barrel.
+	// See https://github.com/opral/paraglide-js/issues/668
+	if (optionsWithDefaults.outputStructure === "message-modules") {
+		output["messages/package.json"] =
+			JSON.stringify({ sideEffects: false }, undefined, "\t") + "\n";
+	}
+
 	for (const [filename, content] of Object.entries(
 		optionsWithDefaults.additionalFiles ?? {}
 	)) {

--- a/src/compiler/compile-project.ts
+++ b/src/compiler/compile-project.ts
@@ -107,10 +107,17 @@ export const compileProject = async (args: {
 	// downloads. Scoped to `messages/` so `runtime.js` (one level up, which has
 	// real side effects) is unaffected. Only relevant for `message-modules`,
 	// the structure with the re-export barrel.
+	//
+	// `type: "module"` is required: this package.json creates a new module scope
+	// for `messages/`, and a package.json without a `type` field defaults to
+	// CommonJS in Node — even when the consuming project is `type: "module"`.
+	// Without it, the generated ESM `.js` files in `messages/` would be treated
+	// as CommonJS and fail to resolve.
 	// See https://github.com/opral/paraglide-js/issues/668
 	if (optionsWithDefaults.outputStructure === "message-modules") {
 		output["messages/package.json"] =
-			JSON.stringify({ sideEffects: false }, undefined, "\t") + "\n";
+			JSON.stringify({ type: "module", sideEffects: false }, undefined, "\t") +
+			"\n";
 	}
 
 	for (const [filename, content] of Object.entries(


### PR DESCRIPTION
Fixes the per-page bundle-size regression reported in #668.

### Problem

The generated message modules are side-effect-free, but each one imports the side-effectful `runtime.js` (the top-level `globalThis.__paraglide = …` writes). Without a side-effect declaration, bundlers — notably **Vite 8 / Rolldown** — cannot prove that dropping an unused re-export from the `m` barrel is safe, so they bundle **every message used anywhere in the app into a single shared chunk that every entry downloads**.

Per-page JS then scales with the *union* of all messages used across the whole app, not with the messages a given route actually uses. Public landing pages end up shipping authenticated/admin strings.

Classic Rollup / Vite 7 split this correctly with no declaration, so it surfaced as a Vite 8 regression — but it's cleanly fixable on paraglide's side, today, on the bundler shipping in Vite 8.

### Fix

Emit a `package.json` next to the generated message modules for `message-modules` output:

```jsonc
// <outdir>/messages/package.json
{ "sideEffects": false }
```

It's scoped to `messages/`, so it declares exactly the pure message modules side-effect-free and leaves `runtime.js` (one directory up) untouched — its `globalThis` SSR side effect is preserved. Rolldown then elides unused re-exports per entry and the barrel splits per route again.

Things that **don't** work, for the record:

- `@__NO_SIDE_EFFECTS__` / `@__PURE__` annotations on the message functions — they govern *call* purity, not *module* side-effect status; the shared chunk persists.
- Making `runtime.js` itself side-effect-free — neither sufficient (the shared chunk still forms) nor safe (it kills the SSR locale setup).

The scoped `package.json` is the actual lever. It's harmless under classic Rollup (already splits) and `sideEffects: false` is webpack's canonical signal too.

### Verified

Real Vite 8 / Rolldown production build of a TanStack Start app (~2,500 messages, ~200 routes), measuring how message strings distribute across client chunks:

| Setup | Shared `messages-*.js` union chunk | Largest chunk's share of all messages |
| --- | --- | --- |
| before (no declaration) | **533 KB — 1665 / 1930 strings** | **86%**, on every page |
| after (`messages/package.json {sideEffects:false}`) | **none** | **16%** (app-shell/common only), spread across 122 route chunks |

`runtime.js`'s `globalThis.__paraglide` writes were confirmed to still land in their own chunk after the change.

### Notes

- Emitted unconditionally for `message-modules` (the structure with the `m` re-export barrel); not emitted for `locale-modules`.
- Unit test added in `compile-project.test.ts`; changeset included (`minor`).
- The full `src/` suite passes; the only failing files locally are pre-existing, unrelated env issues (the `website/` workspace deps and the unbuilt `@inlang/paraglide-js/urlpattern-polyfill` self-import) — identical on `main` without this change.
