### PR TITLE
fix: reuse CSP nonce for locale-splitting injected script

### DIFF
--- a/.changeset/middleware-csp-nonce.md
+++ b/.changeset/middleware-csp-nonce.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+`experimentalMiddlewareLocaleSplitting`: the injected inline script now reuses the nonce from the response's `Content-Security-Policy` header, so it is allowed under a strict CSP instead of being blocked and breaking hydration. Automatic - no configuration needed.

--- a/src/compiler/server/middleware.js
+++ b/src/compiler/server/middleware.js
@@ -184,7 +184,12 @@ export async function paraglideMiddleware(request, resolve, options) {
 		const escapedMessages = messages
 			.join(",")
 			.replace(/<\/(script)/gi, "<\\/$1");
-		const script = `<script>globalThis.__paraglide = globalThis.__paraglide ?? {}; globalThis.__paraglide.ssr = { ${escapedMessages} }</script>`;
+		// Reuse the request's CSP nonce (if any) so the injected script is allowed under a strict CSP
+		const nonce = response.headers
+			.get("Content-Security-Policy")
+			?.match(/'nonce-([\w+/=-]+)'/)?.[1];
+		const nonceAttr = nonce ? `nonce="${nonce}"` : "";
+		const script = `<script ${nonceAttr}>globalThis.__paraglide = globalThis.__paraglide ?? {}; globalThis.__paraglide.ssr = { ${escapedMessages} }</script>`;
 
 		// Insert the script before the closing head tag
 		const newBody = body.replace("</head>", `${script}</head>`);

--- a/src/compiler/server/middleware.test.ts
+++ b/src/compiler/server/middleware.test.ts
@@ -1188,8 +1188,7 @@ test("falls back to original request when cloning a rewritten request fails", as
 		value: class extends NativeRequest {
 			constructor(input: RequestInfo | URL, init?: RequestInit) {
 				if (
-					(typeof input === "string" &&
-						input === "https://example.com/page") ||
+					(typeof input === "string" && input === "https://example.com/page") ||
 					(input instanceof URL && input.href === "https://example.com/page")
 				) {
 					throw new TypeError("Simulated rewritten request clone failure");
@@ -1299,4 +1298,43 @@ test("middleware works with multiple async custom strategies", async () => {
 
 	expect(userPrefCallCount).toBe(2);
 	expect(regionCallCount).toBe(1);
+});
+
+test("injected script reuses the Content-Security-Policy nonce when present and omits it otherwise", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+		strategy: ["globalVariable", "baseLocale"],
+		experimentalMiddlewareLocaleSplitting: true,
+	});
+
+	const request = new Request(new URL("https://example.com/page"), {
+		headers: { "Sec-Fetch-Dest": "document" },
+	});
+
+	// With a CSP nonce -> the injected script reuses it.
+	const responseWithCsp = await runtime.paraglideMiddleware(request, () => {
+		return new Response("<html><head></head><body></body></html>", {
+			headers: {
+				"Content-Type": "text/html",
+				"Content-Security-Policy":
+					"default-src 'self'; script-src 'nonce-abc123' 'strict-dynamic'",
+			},
+		});
+	});
+	expect(await responseWithCsp.text()).toContain('<script nonce="abc123">');
+
+	// Without a CSP header -> the script is still injected, without a nonce.
+	const responseWithoutCsp = await runtime.paraglideMiddleware(request, () => {
+		return new Response("<html><head></head><body></body></html>", {
+			headers: { "Content-Type": "text/html" },
+		});
+	});
+	const html = await responseWithoutCsp.text();
+	expect(html).toContain("globalThis.__paraglide.ssr");
+	expect(html).not.toContain("nonce=");
 });


### PR DESCRIPTION
## Problem
  
With `experimentalMiddlewareLocaleSplitting`, the middleware injects an inline `<script>` into `<head>` carrying the request's messages. The tag had no `nonce`, so under a strict CSP (`script-src 'nonce-…' 'strict-dynamic'`) the browser blocks it → `globalThis.__paraglide.ssr` is never set → hydration breaks.

Ref: #88 (comment https://github.com/opral/paraglide-js/issues/88#issuecomment-4720728821)
  
## Solution

A static `nonce` option doesn't fit: the nonce is generated *per request* (e.g. TanStack Start sets the CSP header inside the `resolve` callback), so it doesn't exist yet at the `paraglideMiddleware(req, resolve)` call site.
  
So the solution I chose is auto-detect the nonce instead of accepting it as input. The middleware injects its script *after* `resolve` (it already does `await response.text()`), and by then the nonce exists on the response - in the `Content-Security-Policy` header, the same source the browser enforces. So the middleware reads the nonce from that header and applies it to the script. Fully automatic - no config, no public API change.
  
  - No CSP / no nonce → plain `<script>` (unchanged behavior).
  - Nonce present → `<script nonce="…">`.
  
  ## Tests

  `src/compiler/server/middleware.test.ts` - one test, two responses: with a CSP header (asserts `<script nonce="abc123">`) and without (asserts the script is still injected and carries no `nonce=`).