### PR TITLE
fix: parse cookie headers without whitespace

### DIFF
--- a/.changeset/fix-cookie-header-parsing.md
+++ b/.changeset/fix-cookie-header-parsing.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Fix server cookie locale parsing when Cookie headers omit whitespace after semicolons.

--- a/src/compiler/runtime/extract-locale-from-request.js
+++ b/src/compiler/runtime/extract-locale-from-request.js
@@ -68,11 +68,14 @@ export const extractLocaleFromRequestWithStrategies = (
 
 	for (const strat of strategies) {
 		if (TREE_SHAKE_COOKIE_STRATEGY_USED && strat === "cookie") {
+			const cookiePrefix = cookieName + "=";
+
 			locale = request.headers
 				.get("cookie")
-				?.split("; ")
-				.find((c) => c.startsWith(cookieName + "="))
-				?.split("=")[1];
+				?.split(";")
+				.map((c) => c.trim())
+				.find((c) => c.startsWith(cookiePrefix))
+				?.slice(cookiePrefix.length);
 		} else if (TREE_SHAKE_URL_STRATEGY_USED && strat === "url") {
 			locale = extractLocaleFromUrl(effectiveRequestUrl);
 		} else if (
@@ -106,7 +109,10 @@ export const extractLocaleFromRequestWithStrategies = (
  * @param {string | URL | undefined} effectiveRequestUrl
  * @returns {URL}
  */
-function resolveEffectiveRequestUrl(request, effectiveRequestUrl = request.url) {
+function resolveEffectiveRequestUrl(
+	request,
+	effectiveRequestUrl = request.url
+) {
 	if (effectiveRequestUrl instanceof URL) {
 		return new URL(effectiveRequestUrl.href);
 	}

--- a/src/compiler/runtime/extract-locale-from-request.test.ts
+++ b/src/compiler/runtime/extract-locale-from-request.test.ts
@@ -22,6 +22,26 @@ test("returns the locale from the cookie", async () => {
 	expect(locale).toBe("fr");
 });
 
+test("returns the locale from a cookie header without whitespace after semicolons", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "fr"],
+			},
+		}),
+		strategy: ["cookie"],
+		cookieName: "PARAGLIDE_LOCALE",
+	});
+	const request = new Request("http://example.com", {
+		headers: {
+			cookie: `PARAGLIDE_LOCALE=fr;session=abc`,
+		},
+	});
+	const locale = runtime.extractLocaleFromRequest(request);
+	expect(locale).toBe("fr");
+});
+
 test("returns the locale from the pathname for document requests", async () => {
 	const runtime = await createParaglide({
 		blob: await newProject({


### PR DESCRIPTION
## Summary

- Parse server Cookie headers by semicolon and trim each segment before matching the locale cookie.
- Add a regression test for Cookie headers like `PARAGLIDE_LOCALE=fr;session=abc`.
- Add a patch changeset.

## Validation

- `pnpm exec vitest run src/compiler/runtime/extract-locale-from-request.test.ts`
- `pnpm exec prettier --check src/compiler/runtime/extract-locale-from-request.js src/compiler/runtime/extract-locale-from-request.test.ts .changeset/fix-cookie-header-parsing.md`
- `pnpm run build`
- `pnpm run test`