### PR TITLE
[codex] docs: clarify Astro SSG setup

### DIFF
--- a/docs/static-site-generation.md
+++ b/docs/static-site-generation.md
@@ -107,6 +107,11 @@ export function generateStaticParams() {
 
 #### Astro (getStaticPaths)
 
+Astro only uses `getStaticPaths()` for static or prerendered routes. If your
+Astro project uses `output: "server"` with Paraglide's server middleware, Astro
+will ignore `getStaticPaths()` for dynamic pages unless the page exports
+`prerender = true`.
+
 ```ts
 // src/pages/[locale]/index.astro
 import { locales } from "../paraglide/runtime.js";
@@ -149,24 +154,43 @@ The recommended approach for Astro SSG is middleware that sets the locale before
 ```ts
 // src/middleware.ts
 import { defineMiddleware } from "astro:middleware";
-import { setLocale, assertIsLocale } from "./paraglide/runtime.js";
+import { assertIsLocale, baseLocale, setLocale } from "./paraglide/runtime.js";
 
 export const onRequest = defineMiddleware((context, next) => {
-  if (context.currentLocale) {
-    setLocale(assertIsLocale(context.currentLocale));
-  }
+  setLocale(assertIsLocale(context.currentLocale ?? baseLocale), {
+    reload: false,
+  });
+
   return next();
 });
 ```
 
-Make sure your `astro.config.mjs` has i18n configured with the same locales defined in your `project.inlang`:
+Do not use `paraglideMiddleware()` for Astro SSG. The server middleware
+de-localizes request URLs for SSR, while static pages need Astro to render each
+localized path directly.
+
+Make sure your `astro.config.mjs` has i18n configured with the same locales
+defined in your `project.inlang`, and include `globalVariable` before
+`baseLocale` so `setLocale()` can store the locale during static rendering:
 
 ```js
+import { defineConfig } from "astro/config";
+import { paraglideVitePlugin } from "@inlang/paraglide-js";
+
 export default defineConfig({
   output: "static",
   i18n: {
     defaultLocale: "en",
     locales: ["en", "de", "fr"], // Must match your project.inlang locales
+  },
+  vite: {
+    plugins: [
+      paraglideVitePlugin({
+        project: "./project.inlang",
+        outdir: "./src/paraglide",
+        strategy: ["url", "globalVariable", "baseLocale"],
+      }),
+    ],
   },
 });
 ```
@@ -229,7 +253,7 @@ SSG typically requires all locales to have a URL prefix so each locale generates
 compile({
   project: "./project.inlang",
   outdir: "./src/paraglide",
-  strategy: ["url", "baseLocale"],
+  strategy: ["url", "globalVariable", "baseLocale"],
   urlPatterns: [
     {
       pattern: "/:path(.*)?",

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -17,7 +17,10 @@ It's a compiler-based i18n library that emits tree-shakable translations, leadin
 [Source code](https://github.com/opral/paraglide-js/tree/main/examples/astro)
 
 > [!NOTE]
-> SSG is not yet supported out of the box. You can integrate Paraglide JS yourself to achieve SSG. PR with an example is welcome.
+> This example uses Astro's server output and Paraglide's server middleware.
+> If you use Astro SSG with `getStaticPaths()`, use `output: "static"` and set
+> the locale during prerendering instead of using `paraglideMiddleware()`. See
+> [Static Site Generation](/static-site-generation#astro-getstaticpaths).
 
 ## Setup
 
@@ -60,6 +63,12 @@ export const onRequest = defineMiddleware((context, next) => {
 ```
 
 You can read more about about Astro's middleware [here](https://docs.astro.build/en/guides/middleware).
+
+> [!IMPORTANT]
+> `output: "server"` makes Astro treat dynamic routes as server-rendered. Astro
+> will ignore `getStaticPaths()` for those routes unless the route opts into
+> prerendering. For fully static localized pages, follow the Astro SSG setup
+> instead of the server middleware setup above.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Clarifies that the Astro example is the SSR/server middleware setup.
- Documents the Astro SSG path for `getStaticPaths()` users: `output: "static"`, Astro `i18n`, and locale-setting middleware without `paraglideMiddleware()`.
- Adds `globalVariable` before `baseLocale` in the SSG strategy so `setLocale()` can store the build-time locale.

## Why

Astro ignores `getStaticPaths()` for dynamic routes under `output: "server"` unless the route opts into prerendering. Paraglide's server middleware is meant for SSR URL de-localization, so it is the wrong setup for fully static localized Astro pages.

Closes #616

## Validation

- Reproduced the Astro warning locally with a dynamic `[locale]` route under `output: "server"`.
- Verified the documented SSG setup in a throwaway Astro `5.17.1` + Paraglide `2.11.0` fixture.
- Docs-only change; no full site build run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API modifications.
> 
> **Overview**
> Documentation now separates **Astro SSG** from the existing **server + `paraglideMiddleware()`** example so readers do not mix setups that trigger `getStaticPaths()` warnings or wrong URL handling.
> 
> The SSG guide adds when Astro honors `getStaticPaths()`, warns against `paraglideMiddleware()` for static builds, and documents middleware that calls `setLocale()` with `reload: false` plus a full `astro.config.mjs` sample (`output: "static"`, Astro `i18n`, Paraglide Vite plugin). SSG strategy examples now use **`["url", "globalVariable", "baseLocale"]`** so build-time `setLocale()` can persist the locale.
> 
> The Astro example README states it is the SSR/server path and links to the SSG section, with an important note that `output: "server"` skips `getStaticPaths()` unless routes opt into prerendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e296181e4817d7cda1363acdf9b4b27d634ffc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->