### PR TITLE
[codex] Document React Router translated pathname aliases

### DIFF
--- a/examples/react-router/README.md
+++ b/examples/react-router/README.md
@@ -112,6 +112,49 @@ export default [
 
 Now you can use `getLocale` function anywhere in your project.
 
+### Translated pathnames
+
+React Router matches the incoming URL against the routes you define in
+`routes.ts`. The middleware can set the locale and request context, but React
+Router's middleware API does not let Paraglide pass a rewritten request to
+`next()` before route matching.
+
+If you use translated pathnames, define localized route aliases in `routes.ts`
+and point them at the same route module. Give each alias a unique route `id`
+when multiple entries use the same file.
+
+```ts
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+export default [
+	index("routes/home.tsx"),
+	route("en/pricing", "routes/pricing.tsx", { id: "pricing-en" }),
+	route("de/preise", "routes/pricing.tsx", { id: "pricing-de" }),
+	route("pl/cennik", "routes/pricing.tsx", { id: "pricing-pl" }),
+] satisfies RouteConfig;
+```
+
+Keep the corresponding Paraglide `urlPatterns` so helpers like
+`localizeHref("/pricing")` generate the public URL that React Router can match:
+
+```ts
+paraglideVitePlugin({
+	project: "./project.inlang",
+	outdir: "./app/paraglide",
+	strategy: ["url", "baseLocale"],
+	urlPatterns: [
+		{
+			pattern: "/pricing",
+			localized: [
+				["en", "/en/pricing"],
+				["de", "/de/preise"],
+				["pl", "/pl/cennik"],
+			],
+		},
+	],
+});
+```
+
 ## Server side rendering without middleware (legacy)
 
 If you can't use middleware yet, you can still wire SSR manually:


### PR DESCRIPTION
## Summary

- add React Router docs for translated pathname aliases
- explain why middleware cannot rewrite the request before React Router route matching
- show route alias examples with unique ids plus matching Paraglide urlPatterns

## Validation

- docs-only change; no test suite run

Closes #548

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the example README; no runtime or build behavior is modified.
> 
> **Overview**
> Adds a **Translated pathnames** section to the React Router example README after the middleware SSR setup.
> 
> It explains that Paraglide middleware cannot rewrite the request before React Router matches routes, so localized URLs need **explicit route aliases** in `routes.ts` (same module, unique `id` per locale path). The doc pairs that with matching **`urlPatterns`** in `paraglideVitePlugin` so `localizeHref` emits URLs React Router can match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e7d93d14a1c89b81a005036bf7ccb6c99979c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->