### PR TITLE
docs: add react-i18next comparison + alternatives pages

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -10,6 +10,9 @@ Paraglide's compiler approach enables optimizations that are not possible with r
 
 If you are looking for a benchmark, check out the [interactive benchmark](/benchmark).
 
+> [!TIP]
+> Coming from a specific library? See the focused guides: [Paraglide JS vs react-i18next](/paraglide-vs-react-i18next) and [react-i18next alternatives](/react-i18next-alternatives).
+
 > [!NOTE]
 > Please open a pull request if the comparison is outdated, incorrect, or can be improved.
 

--- a/docs/paraglide-vs-react-i18next.md
+++ b/docs/paraglide-vs-react-i18next.md
@@ -1,0 +1,134 @@
+---
+title: Paraglide JS vs react-i18next
+og:title: Paraglide JS vs react-i18next (2026) — compiler vs runtime i18n
+description: A side-by-side comparison of Paraglide JS and react-i18next for React + Vite apps — bundle size, type safety, locale switching, rich text, and how to migrate without rewriting your translation files.
+---
+
+# Paraglide JS vs react-i18next
+
+**Paraglide JS is a compiler-first alternative to react-i18next: up to [70% smaller i18n bundles](/benchmark), type safety with zero setup, and a native fit for React + Vite — and you can migrate without rewriting your translation files.**
+
+```bash
+npx @inlang/paraglide-js init
+```
+
+[Try the React + Vite example →](https://github.com/opral/paraglide-js/tree/main/examples/react) · [See the benchmark →](/benchmark)
+
+[react-i18next](https://react.i18next.com/) is the de-facto standard for React i18n, with millions of weekly downloads and a deep ecosystem. The difference is architectural: react-i18next resolves keys from a dictionary **at runtime**, while Paraglide **compiles** your messages into tree-shakable, typed functions **at build time**. This page compares them honestly so you can pick the right one.
+
+## TL;DR
+
+- **Choose Paraglide** if you want the smallest possible i18n bundle, end-to-end type safety with zero setup, and a first-class fit for Vite/ESM build tools. Ideal for greenfield React + Vite apps.
+- **Choose react-i18next** if you depend on a large existing i18next codebase, need translations that are only known at runtime (e.g. CMS-driven keys), or rely on specific i18next plugins and its mature ecosystem.
+- **You don't have to rewrite to try Paraglide.** It can compile your existing i18next JSON files via the [i18next plugin](https://inlang.com/m/3i8bor92/plugin-inlang-i18next) — an integration **officially supported by the i18next team** — so you can migrate incrementally.
+
+## At a glance
+
+| | Paraglide JS | react-i18next |
+| --- | --- | --- |
+| **Architecture** | 🏗️ Compiler (build-time) | 🏃 Runtime dictionary |
+| **i18n bundle size** | [Up to 70% smaller](/benchmark) via per-message tree-shaking | Ships the i18next runtime + your catalogs |
+| **Bundle growth** | Flat — only *used* messages ship | Grows with catalog size |
+| **Type safety** | ✅ Generated typed functions (keys **and** params) | 🟠 Via TypeScript [workarounds](https://www.i18next.com/overview/typescript) |
+| **Setup** | One Vite plugin, no provider/context | `I18nextProvider` + init + hooks |
+| **Calling a message** | `m.greeting({ name })` (plain function) | `t("greeting", { name })` via `useTranslation()` |
+| **Rich text / `<Trans>`** | ✅ Typed [markup adapter](https://paraglidejs.com/markup) | ✅ `<Trans>` component |
+| **Pluralization / ICU** | ✅ `Intl.PluralRules` + [variants](https://paraglidejs.com/variants); [ICU plugin](https://inlang.com/m/p7c8m1d2/plugin-inlang-icu-messageformat-1) | ✅ Mature |
+| **Runtime / CMS-driven keys** | 🟠 Best when keys are known at build time | ✅ Strong |
+| **Ecosystem maturity** | Newer, growing | ✅ Very mature, huge community |
+| **Frameworks** | React, Vite, TanStack Start, SvelteKit, React Router, Astro, Vue, Solid, vanilla | React (with wrappers for other frameworks) |
+
+## Architecture: compiler vs runtime
+
+react-i18next loads your translation catalogs into memory and resolves keys through a `t()` lookup while your app runs. Paraglide compiles each message into its own typed ESM function ahead of time:
+
+```js
+// messages/en.json
+{ "greeting": "Hello {name}!" }
+```
+
+```ts
+// Paraglide — a real, imported function
+import { m } from "./paraglide/messages.js";
+m.greeting({ name: "World" }); // "Hello World!" — fully typesafe
+```
+
+```ts
+// react-i18next — a runtime key lookup
+const { t } = useTranslation();
+t("greeting", { name: "World" });
+```
+
+Because messages are plain functions, your bundler **tree-shakes the ones you don't import**, and TypeScript checks both the key and its parameters.
+
+## Bundle size
+
+In the [Paraglide benchmark](/benchmark) (5 locales, 100 used messages, 200 total), Paraglide shipped **47 KB** vs **205 KB** for i18next. Because only *used* messages ship, Paraglide's bundle stays flat as the catalog grows — 47 KB whether the project has 200, 500, or 1,000 total messages — while the runtime bundle grows from **205 KB to 414 KB**.
+
+If bundle size on a client-rendered React + Vite app is a priority, this is the single biggest difference.
+
+## Type safety
+
+Paraglide generates the message functions, so keys and parameters are typed by default — a renamed or missing message is a **compile error**, and your editor autocompletes both names and arguments. react-i18next can approximate this with [TypeScript augmentation](https://www.i18next.com/overview/typescript), but it's opt-in setup you maintain rather than something you get for free.
+
+## Locale switching in React
+
+react-i18next re-renders subscribed components via `useTranslation()` when you call `i18n.changeLanguage()`.
+
+Paraglide's `setLocale()` **reloads the page by default** so every message re-renders in the new locale — no provider or context to wire up. This is a deliberate design choice: a user switches language once, so a reload keeps the implementation simple and avoids framework-specific logic for preserving form state, scroll position, and the like (the same approach YouTube and other large sites take). If you'd rather drive re-rendering yourself, pass `setLocale("de", { reload: false })`. See [the basics](https://paraglidejs.com/basics).
+
+## Rich text (the `<Trans>` use case)
+
+Both libraries let translators control where links and emphasis go inside a sentence while your app controls how they render. react-i18next uses `<Trans>`; Paraglide uses a typed [markup adapter](https://paraglidejs.com/markup):
+
+```tsx
+import { ParaglideMessage } from "@inlang/paraglide-js-react";
+import { m } from "./paraglide/messages.js";
+
+<ParaglideMessage
+  message={m.cta}
+  markup={{
+    link: ({ children }) => <a href="/contact">{children}</a>,
+    strong: ({ children }) => <strong>{children}</strong>,
+  }}
+/>;
+```
+
+The markup names come from your message and are type-checked. Adapters exist for [React](https://www.npmjs.com/package/@inlang/paraglide-js-react), [Svelte](https://www.npmjs.com/package/@inlang/paraglide-js-svelte), [Vue](https://www.npmjs.com/package/@inlang/paraglide-js-vue), and [Solid](https://www.npmjs.com/package/@inlang/paraglide-js-solid).
+
+## Pluralization & ICU
+
+Paraglide supports plurals and ordinals via `Intl.PluralRules`, plus gender/select through its [variants](https://paraglidejs.com/variants) system. If your team prefers the familiar **ICU MessageFormat** syntax, use the [ICU plugin](https://inlang.com/m/p7c8m1d2/plugin-inlang-icu-messageformat-1):
+
+```
+{count, plural, one {# item} other {# items}}
+```
+
+## Migrating from react-i18next
+
+> [!NOTE]
+> **The i18next team officially supports the inlang/Paraglide integration.** It was built together with the i18next maintainers — see the [joint announcement](https://inlang.com/blog/official-i18next-inlang-init).
+
+You don't have to rewrite your translations. Paraglide can compile your existing i18next JSON files through the official [i18next plugin](https://inlang.com/m/3i8bor92/plugin-inlang-i18next). That means you can:
+
+1. Keep your current `en.json` / `de.json` files and folder structure.
+2. Point Paraglide at them and start importing typed `m.*` functions.
+3. Replace `t("key")` call sites with `m.key()` incrementally — no big-bang rewrite.
+
+## When react-i18next is still the better choice
+
+To be fair: react-i18next remains an excellent, battle-tested choice. Prefer it when:
+
+- **Most keys are only known at runtime** (CMS-driven menus, user-generated content). Compiler tree-shaking and type safety rely on keys being known at build time.
+- **You have a large existing i18next codebase** and team familiarity, and the migration cost outweighs the gains.
+- **You depend on specific i18next plugins** or its broader ecosystem.
+
+## Try Paraglide
+
+```bash
+npx @inlang/paraglide-js init
+```
+
+- [Full React + Vite example](https://github.com/opral/paraglide-js/tree/main/examples/react)
+- [React Router (SSR) guide](https://paraglidejs.com/react-router)
+- [Benchmark](/benchmark) · [Full comparison](/comparison)

--- a/docs/react-i18next-alternatives.md
+++ b/docs/react-i18next-alternatives.md
@@ -1,0 +1,71 @@
+---
+title: react-i18next Alternatives
+og:title: The best react-i18next alternatives for React + Vite (2026)
+description: Looking for a react-i18next alternative? Compare compiler-based and runtime i18n libraries for React + Vite — Paraglide JS, react-intl, LinguiJS, and next-intl — by bundle size, type safety, and DX.
+---
+
+# react-i18next Alternatives
+
+**The strongest react-i18next alternative for React + Vite is [Paraglide JS](https://paraglidejs.com) — a compiler-first library with up to [70% smaller bundles](/benchmark), built-in type safety, and no provider to set up. You can switch without rewriting your translation files.**
+
+```bash
+npx @inlang/paraglide-js init
+```
+
+[React + Vite example →](https://github.com/opral/paraglide-js/tree/main/examples/react) · [Paraglide vs react-i18next →](/paraglide-vs-react-i18next)
+
+[react-i18next](https://react.i18next.com/) is the most popular i18n library for React, but it isn't the only option — and for modern **React + Vite** apps it isn't always the best fit. The most common reasons developers look for an alternative:
+
+- **Bundle size** — runtime libraries ship the whole catalog and an interpreter to the browser.
+- **Type safety** — getting typed keys and parameters in react-i18next requires extra setup.
+- **DX** — a provider, hooks, and string keys add boilerplate.
+
+This page compares the main alternatives honestly so you can pick the right one.
+
+## The alternatives at a glance
+
+| Library | Approach | Bundle | Type safety | Best for |
+| --- | --- | --- | --- | --- |
+| **[Paraglide JS](https://paraglidejs.com)** | 🏗️ Compiler | [Up to 70% smaller](/benchmark), tree-shaken | ✅ Built-in (keys + params) | Vite/ESM apps that want minimal bundle + type safety |
+| [react-intl (FormatJS)](https://formatjs.github.io/) | 🏃 Runtime | Ships catalogs | ❌ | ICU-heavy formatting, large teams |
+| [LinguiJS](https://lingui.dev/) | Extraction + compiled catalogs | Compiled catalogs | 🟠 Macro-based | ICU + extraction workflow |
+| [next-intl](https://next-intl-docs.vercel.app/) | 🏃 Runtime | Ships catalogs | 🟠 Partial | Next.js apps specifically |
+| [typesafe-i18n](https://github.com/ivanhofer/typesafe-i18n) | Runtime + codegen | Small runtime | ✅ Good | ⚠️ No longer actively maintained |
+
+> [!WARNING]
+> **typesafe-i18n** pioneered the type-safe approach but is **no longer actively maintained**, so it's not recommended for new projects. If type safety is what drew you to it, Paraglide offers it built-in on an actively maintained, compiler-based foundation.
+
+## Paraglide JS — the compiler-first alternative
+
+Paraglide is the closest thing to "react-i18next, but compiled." Instead of a runtime `t("key")` lookup, it compiles each message into a typed, tree-shakable function:
+
+```ts
+import { m } from "./paraglide/messages.js";
+m.greeting({ name: "World" }); // typed key + typed params, no provider needed
+```
+
+What you get vs react-i18next:
+
+- **Smaller bundles** — only the messages you import ship; the bundle stays flat as the catalog grows ([benchmark](/benchmark): 47 KB vs 205 KB).
+- **Type safety with zero setup** — renamed or missing messages are compile errors.
+- **No provider/context** — import functions and call them.
+- **Vite-native** — one plugin; works across React, TanStack Start, SvelteKit, React Router, Astro, Vue, Solid, and vanilla JS/TS.
+- **Rich text** via a typed [markup adapter](https://paraglidejs.com/markup) (the `<Trans>` equivalent), and **plurals/ICU** via [variants](https://paraglidejs.com/variants) or the [ICU plugin](https://inlang.com/m/p7c8m1d2/plugin-inlang-icu-messageformat-1).
+
+See the full [Paraglide JS vs react-i18next](/paraglide-vs-react-i18next) comparison.
+
+## Migrate without rewriting
+
+You can keep your existing react-i18next translation files. Paraglide compiles i18next JSON through the [i18next plugin](https://inlang.com/m/3i8bor92/plugin-inlang-i18next) — an integration **officially supported by the i18next team** ([joint announcement](https://inlang.com/blog/official-i18next-inlang-init)) — so you can adopt it incrementally and swap `t("key")` for `m.key()` over time.
+
+## When to stay on react-i18next
+
+If most of your keys are only known at runtime (CMS-driven content), you have a large existing i18next codebase, or you rely on specific i18next plugins, react-i18next remains a solid choice. Compiler-based tools shine when keys are known at build time.
+
+## Try Paraglide
+
+```bash
+npx @inlang/paraglide-js init
+```
+
+[React + Vite example](https://github.com/opral/paraglide-js/tree/main/examples/react) · [Benchmark](/benchmark) · [Full comparison](/comparison)

--- a/marketplace-manifest.json
+++ b/marketplace-manifest.json
@@ -62,6 +62,10 @@
 			"Sherlock VSCode extension": "/m/r7kp499g/app-inlang-ideExtension",
 			"CLI for automation": "/m/2qj2w8pu/app-inlang-cli",
 			"Fink web editor": "/m/tdozzpar/app-inlang-finkLocalizationEditor"
+		},
+		"Appendix": {
+			"/paraglide-vs-react-i18next": "./docs/paraglide-vs-react-i18next.md",
+			"/react-i18next-alternatives": "./docs/react-i18next-alternatives.md"
 		}
 	},
 	"repository": "https://github.com/opral/paraglide-js",


### PR DESCRIPTION
## Why

The same AX-eval showed Paraglide is **absent from organic search** for the natural i18n queries developers and agents use — "react i18n library", "react vite i18n", "react-i18next alternative". Verified via DataForSEO SERP data and agent search cohorts: Paraglide doesn't appear in the top results for any of them, while competitors with SEO-focused comparison content (e.g. Intlayer) rank. Search volume confirms the gap ("react-i18next" ~880/mo; "paraglide js" ~0).

These pages target that demand so search/agents surface Paraglide when someone is actually choosing a library.

## What's added

- **`/paraglide-vs-react-i18next`** — honest head-to-head (architecture, bundle size, type safety, locale switching, rich text, pluralization), an explicit **"officially supported by the i18next team"** callout linking the [joint announcement](https://inlang.com/blog/official-i18next-inlang-init), a migrate-without-rewriting section, and an honest "when react-i18next is still the better choice."
- **`/react-i18next-alternatives`** — alternatives landing page positioning Paraglide among react-intl, Lingui, next-intl (typesafe-i18n flagged as no longer maintained).
- Registered both in `marketplace-manifest.json` under a new **Appendix** nav group (kept out of the main nav so it doesn't clutter the docs for humans; still SSG'd, indexable, and cross-linked from `/comparison`).

All claims fact-checked against the repo (benchmark numbers, adapters, ICU plugin, reload behavior, i18next integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and site manifest routing only; no library, build, or runtime behavior changes.
> 
> **Overview**
> Adds **two new SEO-focused docs** for developers evaluating React i18n: **`/paraglide-vs-react-i18next`** (head-to-head on compiler vs runtime, bundles, types, locale switching, rich text, migration via the i18next plugin, plus when to stay on react-i18next) and **`/react-i18next-alternatives`** (landscape table for Paraglide, react-intl, Lingui, next-intl, with typesafe-i18n marked unmaintained).
> 
> Both routes are registered in **`marketplace-manifest.json`** under a new **Appendix** nav group (off the main docs nav but still published). **`/comparison`** gets a tip block linking to these focused guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d62050e420c0a643f8a0b707c443e7917a7aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->