### PR TITLE
fix emitTsDeclarations with TypeScript 7

### DIFF
--- a/.changeset/ts7-emit-declarations.md
+++ b/.changeset/ts7-emit-declarations.md
@@ -1,5 +1,5 @@
 ---
-"@inlang/paraglide-js": patch
+"@inlang/paraglide-js": minor
 ---
 
 fix `emitTsDeclarations` with TypeScript 7 https://github.com/opral/paraglide-js/issues/711

--- a/.changeset/ts7-emit-declarations.md
+++ b/.changeset/ts7-emit-declarations.md
@@ -1,0 +1,9 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix `emitTsDeclarations` with TypeScript 7 https://github.com/opral/paraglide-js/issues/711
+
+TypeScript 7 (the Go-based compiler) no longer ships the in-process compiler API that Paraglide used to generate `.d.ts` files, which made `paraglide-js compile --emit-ts-declarations` fail with `TypeError: Cannot read properties of undefined (reading 'ESNext')`. Paraglide now detects this and invokes TypeScript's `tsc` CLI instead. TypeScript 5 and 6 keep using the compiler API as before.
+
+Note that the declaration output of TypeScript 7 differs cosmetically from TypeScript 5/6 (quote style, declaration ordering, `export declare const` vs `export const`) but is semantically equivalent.

--- a/docs/compiling-messages.md
+++ b/docs/compiling-messages.md
@@ -141,6 +141,9 @@ paraglideVitePlugin({
 > [!NOTE]
 > Emitting declarations requires the `typescript` package and is slower than JSDoc-based types. Use `allowJs: true` when possible for faster compilation.
 
+> [!NOTE]
+> With TypeScript 5 and 6, declarations are generated with the in-process compiler API. TypeScript 7+ no longer provides that API, so Paraglide invokes its `tsc` CLI in a child process instead. The output is semantically equivalent, but differs cosmetically between the two (quote style, declaration ordering, `export declare const` vs `export const`) — expect `.d.ts` churn when switching TypeScript majors.
+
 ## Generated Output
 
 The compiler generates the following file structure in your `outdir`:

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"typedoc-plugin-markdown": "4.7.0",
 		"typedoc-plugin-missing-exports": "4.0.0",
 		"typescript": "5.9.2",
+		"typescript-go": "npm:typescript@7.0.2",
 		"vitest": "3.1.4"
 	},
 	"keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      typescript-go:
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       vitest:
         specifier: 3.1.4
         version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
@@ -3139,6 +3142,126 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -6251,6 +6374,11 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -9625,6 +9753,66 @@ snapshots:
     optional: true
 
   '@types/unist@3.0.3': {}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -13406,6 +13594,29 @@ snapshots:
   typescript@5.9.2: {}
 
   typescript@5.9.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uc.micro@2.1.0: {}
 

--- a/src/compiler/compiler-options.ts
+++ b/src/compiler/compiler-options.ts
@@ -278,6 +278,11 @@ export type CompilerOptions = {
 	 * **Note:** Enabling this option reduces compiler speed because TypeScript
 	 * needs to generate declaration files for all output modules.
 	 *
+	 * **Note:** With TypeScript 5/6 the declarations are generated in-process.
+	 * TypeScript 7+ no longer provides the compiler API, so its `tsc` CLI is
+	 * invoked in a child process instead; the emitted declarations are
+	 * semantically equivalent but differ cosmetically between the two.
+	 *
 	 * @example
 	 * ```ts
 	 * await compile({

--- a/src/compiler/emit-ts-declarations.interop.test.ts
+++ b/src/compiler/emit-ts-declarations.interop.test.ts
@@ -1,0 +1,74 @@
+import { expect, test, vi } from "vitest";
+import {
+	type BundleNested,
+	insertBundleNested,
+	loadProjectInMemory,
+	newProject,
+} from "@inlang/sdk";
+import { compileProject } from "./compile-project.js";
+
+// Bundlers and CJS interop can deliver the `typescript` module in a
+// default-only shape (`{ default: ts }` without hoisted named exports).
+// TypeScript 5/6 in that shape must still be routed to the in-process
+// compiler API: the CLI fallback intended for TypeScript 7+ would run
+// TypeScript 5's `tsc`, whose declaration emitter produces syntactically
+// invalid unquoted export aliases (`export { x as a.b }`).
+//
+// `createProgram: undefined` is stubbed explicitly because vitest wraps
+// factory mocks in a proxy that throws on missing exports, while a real
+// default-only namespace returns `undefined`.
+vi.mock("typescript", async () => {
+	const actual =
+		await vi.importActual<typeof import("typescript")>("typescript");
+	return {
+		default: actual,
+		createProgram: undefined,
+	};
+});
+
+test("emitTsDeclarations uses the compiler API for a default-only interop shape of TypeScript 5", async () => {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				locales: ["en"],
+				baseLocale: "en",
+			},
+		}),
+	});
+
+	const bundle: BundleNested = {
+		id: "greeting.hello",
+		declarations: [],
+		messages: [
+			{
+				id: "greeting.hello_en",
+				bundleId: "greeting.hello",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "greeting.hello_en_variant",
+						messageId: "greeting.hello",
+						matches: [],
+						pattern: [{ type: "text", value: "Hello" }],
+					},
+				],
+			},
+		],
+	};
+	await insertBundleNested(project.db, bundle);
+
+	const output = await compileProject({
+		project,
+		compilerOptions: {
+			emitTsDeclarations: true,
+		},
+	});
+
+	expect(output).toHaveProperty("runtime.d.ts");
+	// the quoted alias distinguishes the two paths: TypeScript 5's CLI would
+	// emit the invalid `export { greeting_hello as greeting.hello }` instead
+	expect(output["messages/greeting_hello.d.ts"]).toContain(
+		`export { greeting_hello as "greeting.hello" };`
+	);
+});

--- a/src/compiler/emit-ts-declarations.test.ts
+++ b/src/compiler/emit-ts-declarations.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { createProject as typescriptProject, ts } from "@ts-morph/bootstrap";
+import {
+	type BundleNested,
+	insertBundleNested,
+	loadProjectInMemory,
+	newProject,
+} from "@inlang/sdk";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { compileProject } from "./compile-project.js";
+
+// TypeScript 7 (the Go-based compiler, npm `latest` since 7.0.2) no longer
+// ships the in-process compiler API. Its main entry point only exports
+// `version` and `versionMajorMinor` — no `createProgram`, no `ScriptTarget`,
+// no `ModuleKind`. Emitting declarations must go through the `tsc` CLI
+// instead. https://github.com/opral/paraglide-js/issues/711
+//
+// The repo's own `typescript` dev dependency stays on 5.x for the existing
+// tests; this file swaps in the aliased TypeScript 7 package to simulate a
+// user who upgraded.
+//
+// Note: vitest wraps factory mocks in a proxy that throws on missing exports.
+// The real TypeScript 7 module returns `undefined` for them instead, so the
+// classic compiler API surface is stubbed out explicitly to mirror that.
+vi.mock("typescript", async () => {
+	const actual =
+		await vi.importActual<typeof import("typescript-go")>("typescript-go");
+	return {
+		...actual,
+		createProgram: undefined,
+		createCompilerHost: undefined,
+		createSourceFile: undefined,
+		ScriptTarget: undefined,
+		ScriptKind: undefined,
+		ModuleKind: undefined,
+		ModuleResolutionKind: undefined,
+	};
+});
+
+// In production, the `typescript` module and the `tsc` CLI resolve to the
+// same package. In this test the module is mocked with the TypeScript 7
+// alias, so the CLI resolution must point at that alias too — otherwise it
+// would find the repo's TypeScript 5 dev dependency. Mutable so the error
+// path can be tested with a broken resolution.
+const tscResolution = vi.hoisted(() => ({ tscJsPath: "" }));
+
+vi.mock("./resolve-tsc-js-path.js", () => ({
+	resolveTscJsPath: () => tscResolution.tscJsPath,
+}));
+
+const typescriptGoTscJsPath = path.join(
+	path.dirname(
+		createRequire(import.meta.url).resolve("typescript-go/package.json")
+	),
+	"lib",
+	"tsc.js"
+);
+
+beforeEach(() => {
+	tscResolution.tscJsPath = typescriptGoTscJsPath;
+});
+
+async function newProjectWithMessages() {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				locales: ["en"],
+				baseLocale: "en",
+			},
+		}),
+	});
+
+	// a message id that is not a valid JS identifier -> quoted export alias
+	const quotedAliasBundle: BundleNested = {
+		id: "greeting.hello",
+		declarations: [],
+		messages: [
+			{
+				id: "greeting.hello_en",
+				bundleId: "greeting.hello",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "greeting.hello_en_variant",
+						messageId: "greeting.hello",
+						matches: [],
+						pattern: [{ type: "text", value: "Hello" }],
+					},
+				],
+			},
+		],
+	};
+
+	// a message with an input so the declarations carry a typed parameter
+	const parameterizedBundle: BundleNested = {
+		id: "balance",
+		declarations: [{ type: "input-variable", name: "amount" }],
+		messages: [
+			{
+				id: "balance_en",
+				bundleId: "balance",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "balance_en_variant",
+						messageId: "balance",
+						matches: [],
+						pattern: [
+							{ type: "text", value: "You have " },
+							{
+								type: "expression",
+								arg: { type: "variable-reference", name: "amount" },
+							},
+							{ type: "text", value: " coins." },
+						],
+					},
+				],
+			},
+		],
+	};
+
+	await insertBundleNested(project.db, quotedAliasBundle);
+	await insertBundleNested(project.db, parameterizedBundle);
+	return project;
+}
+
+test("emitTsDeclarations works with TypeScript 7 (tsgo)", async () => {
+	const project = await newProjectWithMessages();
+
+	for (const outputStructure of [
+		"message-modules",
+		"locale-modules",
+	] as const) {
+		const output = await compileProject({
+			project,
+			compilerOptions: {
+				emitTsDeclarations: true,
+				outputStructure,
+			},
+		});
+
+		expect(output).toHaveProperty("runtime.d.ts");
+		expect(output).toHaveProperty("messages.d.ts");
+		expect(output).toHaveProperty("registry.d.ts");
+		expect(output["runtime.d.ts"]).toContain("getLocale");
+
+		// TypeScript 5's declaration emitter drops the quotes around export
+		// aliases that are not valid identifiers (worked around by a custom
+		// transformer on the compiler-API path); tsgo emits them correctly.
+		const declarationFile =
+			outputStructure === "message-modules"
+				? "messages/greeting_hello.d.ts"
+				: "messages/_index.d.ts";
+
+		expect(output[declarationFile]).toContain(`as "greeting.hello"`);
+
+		// the emitted declarations must typecheck for a consumer
+		// (@ts-morph/bootstrap bundles its own compiler and is unaffected
+		// by the TypeScript 7 mock above)
+		const tsProject = await typescriptProject({
+			useInMemoryFileSystem: true,
+			compilerOptions: {
+				module: ts.ModuleKind.Node16,
+				moduleResolution: ts.ModuleResolutionKind.Node16,
+				strict: true,
+			},
+		});
+
+		for (const [fileName, code] of Object.entries(output)) {
+			if (fileName.endsWith(".d.ts")) {
+				tsProject.createSourceFile(fileName, code);
+			}
+		}
+
+		tsProject.createSourceFile(
+			"test.ts",
+			`
+				import { "greeting.hello" as greetingHello, balance } from "./messages.js";
+
+				greetingHello() satisfies string;
+				balance({ amount: 5 }) satisfies string;
+			`
+		);
+
+		const program = tsProject.createProgram();
+		const diagnostics = ts.getPreEmitDiagnostics(program);
+		for (const diagnostic of diagnostics) {
+			console.error(diagnostic.messageText, diagnostic.file?.fileName);
+		}
+		expect(diagnostics.length).toEqual(0);
+	}
+});
+
+test("emitTsDeclarations throws a descriptive error when the tsc CLI produces no declarations", async () => {
+	tscResolution.tscJsPath = path.join(
+		path.dirname(typescriptGoTscJsPath),
+		"does-not-exist.js"
+	);
+
+	const project = await newProjectWithMessages();
+
+	await expect(
+		compileProject({
+			project,
+			compilerOptions: {
+				emitTsDeclarations: true,
+			},
+		})
+	).rejects.toThrow(/did not produce a declaration file for every compiled/);
+});

--- a/src/compiler/emit-ts-declarations.test.ts
+++ b/src/compiler/emit-ts-declarations.test.ts
@@ -139,8 +139,18 @@ test("emitTsDeclarations works with TypeScript 7 (tsgo)", async () => {
 			compilerOptions: {
 				emitTsDeclarations: true,
 				outputStructure,
+				// path-traversing keys (incl. Windows separators) must be
+				// silently skipped like on the compiler-API path — neither
+				// escaping the temp dir nor failing the completeness check
+				additionalFiles: {
+					"../escape.js": "export const escape = 1;",
+					"foo\\..\\..\\escape.js": "export const escape = 1;",
+				},
 			},
 		});
+
+		expect(output["../escape.d.ts"]).toBeUndefined();
+		expect(output["foo\\..\\..\\escape.d.ts"]).toBeUndefined();
 
 		expect(output).toHaveProperty("runtime.d.ts");
 		expect(output).toHaveProperty("messages.d.ts");

--- a/src/compiler/emit-ts-declarations.ts
+++ b/src/compiler/emit-ts-declarations.ts
@@ -1,4 +1,11 @@
 import path from "node:path";
+import fs from "node:fs/promises";
+import os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { resolveTscJsPath } from "./resolve-tsc-js-path.js";
+
+const execFileAsync = promisify(execFile);
 
 type TypeScript = typeof import("typescript");
 
@@ -33,6 +40,44 @@ export async function emitTsDeclarations(
 		return {};
 	}
 
+	// TypeScript 7+ (the Go-based compiler) no longer ships the in-process
+	// compiler API — its main entry point only exports version metadata.
+	// https://github.com/opral/paraglide-js/issues/711
+	const compilerApi = resolveCompilerApi(ts);
+	if (compilerApi === undefined) {
+		return emitWithTscCli(jsEntries);
+	}
+
+	return emitWithCompilerApi(compilerApi, jsEntries);
+}
+
+/**
+ * Returns the in-process compiler API (TypeScript 5/6), or `undefined` when
+ * the installed TypeScript does not provide one (TypeScript 7+).
+ *
+ * Unwraps default-only interop shapes (`{ default: ts }`) that bundlers and
+ * CJS interop can produce. Without the unwrap, TypeScript 5/6 would be
+ * misrouted to the CLI path, whose TypeScript 5 declaration emitter produces
+ * syntactically invalid quoted export aliases.
+ */
+function resolveCompilerApi(ts: TypeScript): TypeScript | undefined {
+	if (typeof ts.createProgram === "function") {
+		return ts;
+	}
+	const defaultExport = (ts as { default?: TypeScript }).default;
+	if (defaultExport && typeof defaultExport.createProgram === "function") {
+		return defaultExport;
+	}
+	return undefined;
+}
+
+/**
+ * Emits declarations with the in-process TypeScript compiler API (TypeScript 5/6).
+ */
+async function emitWithCompilerApi(
+	ts: TypeScript,
+	jsEntries: [string, string][]
+): Promise<Record<string, string>> {
 	const virtualRoot = path.join(process.cwd(), "__paraglide_virtual_output");
 	const normalizeFileName = (fileName: string) =>
 		path.normalize(
@@ -157,6 +202,142 @@ export async function emitTsDeclarations(
 	});
 
 	return declarations;
+}
+
+const failedToEmitWithTscMessage = `Paraglide's "emitTsDeclarations" option failed to generate declaration files with the installed TypeScript version.
+
+TypeScript 7+ no longer provides the in-process compiler API, so Paraglide invokes its "tsc" CLI instead — which did not produce a declaration file for every compiled file. As a workaround, install TypeScript 5 or 6, or disable "emitTsDeclarations".`;
+
+/**
+ * Emits declarations by invoking the `tsc` CLI of the installed TypeScript
+ * package (TypeScript 7+, where the in-process compiler API is unavailable).
+ *
+ * The compiled output is written to a temporary directory because the
+ * Go-based compiler cannot read from a virtual filesystem.
+ */
+async function emitWithTscCli(
+	jsEntries: [string, string][]
+): Promise<Record<string, string>> {
+	// entries escaping the output root cannot be declared safely; the
+	// compiler-API path silently drops them too (see the writeFile hook)
+	const safeEntries = jsEntries.filter(([fileName]) => {
+		const normalized = path.posix.normalize(fileName);
+		return (
+			normalized.startsWith("..") === false &&
+			path.posix.isAbsolute(normalized) === false
+		);
+	});
+
+	// resolved before spawning so a missing tsc entry point surfaces its own
+	// pointed error instead of the generic "no declaration files" one
+	const tscJsPath = resolveTscJsPath();
+
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "paraglide-dts-"));
+
+	try {
+		const srcDir = path.join(tempDir, "src");
+		const outDir = path.join(tempDir, "dist");
+		await fs.mkdir(outDir, { recursive: true });
+
+		for (const [fileName, content] of safeEntries) {
+			const filePath = path.join(srcDir, fileName);
+			await fs.mkdir(path.dirname(filePath), { recursive: true });
+			await fs.writeFile(filePath, content);
+		}
+
+		const tsconfigPath = path.join(tempDir, "tsconfig.json");
+		await fs.writeFile(
+			tsconfigPath,
+			JSON.stringify({
+				compilerOptions: {
+					allowJs: true,
+					checkJs: true,
+					declaration: true,
+					emitDeclarationOnly: true,
+					esModuleInterop: true,
+					lib: ["ESNext", "DOM"],
+					module: "ESNext",
+					moduleResolution: "bundler",
+					// Declaration emit does not need a typecheck; skipping it also
+					// suppresses diagnostics about the project's environment (e.g.
+					// a missing @types/node) that are irrelevant to the output.
+					noCheck: true,
+					noEmitOnError: false,
+					outDir: "./dist",
+					rootDir: "./src",
+					skipLibCheck: true,
+					target: "ESNext",
+				},
+				files: safeEntries.map(([fileName]) => `./src/${fileName}`),
+			})
+		);
+
+		let tscError: unknown;
+		try {
+			await execFileAsync(
+				process.execPath,
+				[tscJsPath, "--project", tsconfigPath],
+				{
+					maxBuffer: 64 * 1024 * 1024,
+					// Electron-based hosts must execute tsc with their embedded
+					// Node instead of launching another instance of the host app.
+					// Harmless under node and bun.
+					env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+				}
+			);
+		} catch (error) {
+			// tsc exits non-zero when the input has diagnostics even though the
+			// declaration files are still emitted (noEmitOnError is false).
+			// Success is judged by the presence of declaration files below.
+			tscError = error;
+		}
+
+		const declarations: Record<string, string> = {};
+
+		for (const entry of await fs.readdir(outDir, { recursive: true })) {
+			if (entry.endsWith(".d.ts")) {
+				declarations[entry.split(path.sep).join(path.posix.sep)] =
+					await fs.readFile(path.join(outDir, entry), "utf-8");
+			}
+		}
+
+		// tsc emits exactly one .d.ts per input .js (even for inputs with
+		// syntax errors), so a count mismatch means the compiler died mid-emit
+		// and the result would be silently incomplete.
+		if (Object.keys(declarations).length !== safeEntries.length) {
+			throw new Error(withTscOutput(failedToEmitWithTscMessage, tscError), {
+				cause: tscError,
+			});
+		}
+
+		return declarations;
+	} finally {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Appends the spawned compiler's output to the error message.
+ *
+ * tsc writes diagnostics to stdout, which `execFile` errors expose only as a
+ * property — not in the message — so error reporters that print only
+ * message/stack would otherwise hide the reason the emit failed.
+ */
+function withTscOutput(message: string, tscError: unknown): string {
+	const { stdout, stderr } = (tscError ?? {}) as {
+		stdout?: unknown;
+		stderr?: unknown;
+	};
+	const output = [stdout, stderr]
+		.filter((value): value is string => typeof value === "string")
+		.join("\n")
+		.trim();
+	if (output === "") {
+		return message;
+	}
+	const truncated =
+		output.length > 4000 ? output.slice(0, 4000) + "\n… (truncated)" : output;
+	return `${message}\n\nCompiler output:\n${truncated}`;
 }
 
 type QuotedExportAliases = Map<string, Map<string, Set<string>>>;

--- a/src/compiler/emit-ts-declarations.ts
+++ b/src/compiler/emit-ts-declarations.ts
@@ -219,14 +219,18 @@ async function emitWithTscCli(
 	jsEntries: [string, string][]
 ): Promise<Record<string, string>> {
 	// entries escaping the output root cannot be declared safely; the
-	// compiler-API path silently drops them too (see the writeFile hook)
-	const safeEntries = jsEntries.filter(([fileName]) => {
-		const normalized = path.posix.normalize(fileName);
-		return (
-			normalized.startsWith("..") === false &&
-			path.posix.isAbsolute(normalized) === false
-		);
-	});
+	// compiler-API path silently drops them too (see the writeFile hook).
+	// Checked against both separator conventions because path.join interprets
+	// backslashes on Windows (`foo\..\..\x.js` would escape the temp dir).
+	const safeEntries = jsEntries.filter(([fileName]) =>
+		[path.posix, path.win32].every((platformPath) => {
+			const normalized = platformPath.normalize(fileName);
+			return (
+				normalized.startsWith("..") === false &&
+				platformPath.isAbsolute(normalized) === false
+			);
+		})
+	);
 
 	// resolved before spawning so a missing tsc entry point surfaces its own
 	// pointed error instead of the generic "no declaration files" one

--- a/src/compiler/resolve-tsc-js-path.ts
+++ b/src/compiler/resolve-tsc-js-path.ts
@@ -1,0 +1,25 @@
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolves the path to the `tsc` CLI entry point of the installed
+ * `typescript` package.
+ *
+ * Lives in its own module so tests can point the TypeScript 7 emit
+ * path at a different TypeScript installation than the one the repo
+ * itself depends on.
+ */
+export function resolveTscJsPath(): string {
+	const require = createRequire(import.meta.url);
+	const packageJsonPath = require.resolve("typescript/package.json");
+	const tscJsPath = path.join(path.dirname(packageJsonPath), "lib", "tsc.js");
+	// `lib/tsc.js` is internal package layout rather than a public export, so
+	// fail with a pointed error if a future TypeScript version moves it.
+	if (existsSync(tscJsPath) === false) {
+		throw new Error(
+			`Paraglide's "emitTsDeclarations" option could not locate TypeScript's "tsc" CLI at ${tscJsPath}. As a workaround, install TypeScript 5 or 6, or disable "emitTsDeclarations".`
+		);
+	}
+	return tscJsPath;
+}


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/711

## Problem

TypeScript 7 (the Go-based compiler, npm `latest` since 7.0.2) no longer ships the in-process compiler API. Its main entry point only exports `version` and `versionMajorMinor` — no `createProgram`, no `ScriptTarget`, no `ModuleKind`. `paraglide-js compile --emit-ts-declarations` therefore crashed with:

```
TypeError: Cannot read properties of undefined (reading 'ESNext')
```

## Fix

`emitTsDeclarations` now dispatches on capability:

- **TypeScript 5/6** (compiler API present): the pre-existing in-process path, byte-identical output, unchanged.
- **TypeScript 7+** (API absent): writes the compiled JS to a temp directory and invokes the installed TypeScript's `tsc` CLI (the stable interface of the Go compiler), then reads the emitted `.d.ts` files back.

Notes on the CLI path:

- `isolatedDeclarations` is dropped (tsgo rejects it combined with `allowJs`; the TS 5 API path never validated it, so it was inert) and `noCheck` is set — declaration emit needs no typecheck, and this suppresses environment-dependent diagnostics (e.g. missing `@types/node`).
- The custom quoted-export-alias transformer is not needed on this path: tsgo natively emits `export { x as "a.b" }` correctly (the transformer works around a TS 5 emitter bug that produces the invalid unquoted form).
- Success is judged by one emitted `.d.ts` per input `.js` rather than the exit code (tsc exits non-zero on pre-existing diagnostics even when emit succeeds; a count mismatch means the compiler died mid-emit). On failure, the compiler's output is appended to the error message.
- The dispatcher unwraps default-only interop shapes (`{ default: ts }`) so bundled/CJS-interop TypeScript 5/6 is never misrouted to the CLI path.
- The child is spawned with `ELECTRON_RUN_AS_NODE=1` so Electron-based hosts execute tsc instead of launching another app instance.

TS 7 declaration output differs cosmetically from TS 5/6 (quote style, declaration ordering, `export declare const` vs `export const`) but is semantically equivalent; documented in `docs/compiling-messages.md`.

## Tests

- `emit-ts-declarations.test.ts` simulates a TS 7 install via a `typescript-go` (`npm:typescript@7.0.2`) dev-dependency alias: asserts the full file set, the quoted export alias, a passing consumer typecheck of the emitted declarations (via `@ts-morph/bootstrap`, incl. a parameterized message), for both output structures, plus the descriptive-error path.
- `emit-ts-declarations.interop.test.ts` pins that a default-only-wrapped TypeScript 5 routes to the compiler API path (misrouting to the CLI would emit syntactically invalid unquoted aliases).
- Existing TS 5 tests pass unchanged.

Verified end-to-end with a packed tarball: `bun` + `typescript@7.0.2` (the reporter's exact setup) and `node` + `typescript@5` both compile successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes declaration generation and spawns `tsc` in a child process for TS 7 users, but TS 5/6 behavior is preserved and coverage includes interop and failure paths.
> 
> **Overview**
> Fixes **`emitTsDeclarations`** when TypeScript 7 is installed: the Go-based compiler no longer exposes the in-process API, which caused `compile --emit-ts-declarations` to crash reading `ESNext` from undefined.
> 
> **`emitTsDeclarations`** now picks a path by capability: **TypeScript 5/6** still use the existing in-process compiler API (including unwrapping `{ default: ts }` so bundled/CJS interop is not sent to the CLI). **TypeScript 7+** write generated `.js` to a temp directory, run the installed package’s **`tsc`** via a child process (`resolveTscJsPath`), and collect `.d.ts` files; success is validated by one declaration per input file, with clearer errors (including `tsc` stdout/stderr) on failure.
> 
> Docs and compiler-option notes describe cosmetic `.d.ts` differences between majors. Tests add a TS 7 simulation (`typescript-go` alias), an interop test for default-only TS 5, and a broken-`tsc` error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780dcae7148272f344de9f93702cd47d0db9d736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->