### PR TITLE
feat: add experimental per-locale Vite builds

### DIFF
--- a/.changeset/tidy-dodos-split.md
+++ b/.changeset/tidy-dodos-split.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": minor
+---
+
+Add experimental Vite 8 per-locale client builds for TanStack Start and SvelteKit. Enable the same `experimentalPerLocaleBuild: true` flag in either framework; Paraglide detects the framework and serves compiler-specialized client assets for each locale.

--- a/docs/compiling-messages.md
+++ b/docs/compiling-messages.md
@@ -76,6 +76,63 @@ export default defineConfig({
 });
 ```
 
+#### Experimental per-locale builds
+
+On Vite 8.x, TanStack Start and SvelteKit can emit a separate client asset graph
+for every project locale. Paraglide detects the framework, reads the locale
+list automatically, and specializes the compiled message functions at build
+time, so each graph contains only one locale's translations.
+
+```ts
+paraglideVitePlugin({
+	project: "./project.inlang",
+	outdir: "./src/paraglide",
+	experimentalPerLocaleBuild: true,
+});
+```
+
+TanStack Start must use the generated server entry:
+
+```ts
+// src/server.ts
+export { default } from "./paraglide/tanstack-start.server.js";
+```
+
+SvelteKit keeps using its normal `paraglideMiddleware` server hook. Paraglide
+integrates with SvelteKit's renderer automatically, including SSR, prerendered
+HTML, preload headers, and client bootstrap imports.
+
+The base locale keeps the canonical asset URLs. TanStack Start locale trees
+are emitted under `/__paraglide/<locale-id>/`; SvelteKit locale trees stay
+inside its immutable cache directory at
+`/_app/immutable/__paraglide/<locale-id>/`.
+The emitted `paraglide-per-locale.json` indexes the locale prefixes and asset
+mappings.
+
+Locale switching must use full navigation (the default behavior of
+`setLocale()`), because a hydrated page cannot mix two specialized graphs. In
+SvelteKit, add `data-sveltekit-reload` to links which can change locale. If a
+client message call supplies a different `options.locale`, Paraglide warns and
+uses the locale already selected for that client graph.
+
+The experiment intentionally supports a narrow, fail-fast configuration:
+
+- Vite 8.x and a tested framework version: TanStack Start 1.168.x or SvelteKit
+  2.69.x.
+- A global locale strategy whose first entry is `url` or `cookie`, without
+  `routeStrategies`.
+- Root/default asset hosting. Do not configure Vite `base`, source maps,
+  `build.minify: false`, or `experimental.renderBuiltUrl`.
+- TanStack Start must use the generated server entry shown above.
+- SvelteKit must use the default `_app`, empty `kit.paths.base` and
+  `kit.paths.assets`, `bundleStrategy: "split"`, and client router resolution.
+  Service workers and SPA fallback pages are not supported; use SSR or
+  prerender every localized page.
+
+Paraglide rejects unsupported combinations during configuration or build. It
+performs the required final Oxc minification itself and does not emit client
+source maps.
+
 ### Webpack
 
 ```js
@@ -164,11 +221,11 @@ paraglide/
 
 **Key files:**
 
-| File | Purpose |
-|------|---------|
+| File          | Purpose                                                                  |
+| ------------- | ------------------------------------------------------------------------ |
 | `messages.js` | Import message functions: `import * as m from "./paraglide/messages.js"` |
-| `runtime.js` | Locale utilities: `getLocale()`, `setLocale()`, `locales`, `baseLocale` |
-| `server.js` | Server middleware: `paraglideMiddleware()` |
+| `runtime.js`  | Locale utilities: `getLocale()`, `setLocale()`, `locales`, `baseLocale`  |
+| `server.js`   | Server middleware: `paraglideMiddleware()`                               |
 
 The `outputStructure` option controls how messages are organized. See [Compiler Options](./compiler-options) for details.
 

--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -47,6 +47,7 @@ export default defineConfig({
 +		paraglideVitePlugin({
 +			project: './project.inlang',
 +			outdir: './src/lib/paraglide',
++			experimentalPerLocaleBuild: true,
 +			strategy: ['url', 'cookie', 'baseLocale'],
 +		})
 	]
@@ -88,6 +89,22 @@ const paraglideHandle: Handle = ({ event, resolve }) =>
 export const handle: Handle = paraglideHandle;
 ```
 
+With `experimentalPerLocaleBuild: true`, this same hook also gives SvelteKit's
+renderer the request-local locale used to select the client asset graph. No
+additional SvelteKit adapter option is needed. The feature requires Vite 8 and
+is currently tested with SvelteKit 2.69.x. The base locale keeps the normal
+`_app/immutable` URLs; other locales are emitted below
+`_app/immutable/__paraglide/<locale-id>/` so SvelteKit adapters retain their
+immutable caching behavior.
+
+The experiment intentionally supports SvelteKit's default asset and router
+layout: Vite 8.x, `kit.appDir: "_app"`, empty `kit.paths.base` and
+`kit.paths.assets`, `kit.output.bundleStrategy: "split"`, and
+`kit.router.resolution: "client"`. The global locale strategy must start with
+`url` or `cookie`; `routeStrategies`, service workers, Vite `base`, source
+maps, and `build.minify: false` are rejected. Unsupported combinations fail
+during configuration or build.
+
 #### Add a reroute hook in `src/hooks.ts`
 
 IMPORTANT: The `reroute()` function must be exported from the `src/hooks.ts` file, not `src/hooks.server.ts`.
@@ -128,6 +145,11 @@ Enable [pre-rendering](https://svelte.dev/docs/kit/page-options#prerender) by ad
 
 Then add a locale switcher in `routes/+layout.svelte` to generate all pages during build time. SvelteKit crawls anchor tags during the build and is, thereby, able to generate all pages statically. If you already have a visible locale switcher that links to every locale variant, nothing extra is required. Add `data-sveltekit-reload` (see [paraglide-js#472](https://github.com/opral/paraglide-js/issues/472)) so locale switches trigger a full reload and the new locale is applied.
 
+Full reloads are required by `experimentalPerLocaleBuild`: client-side
+navigation must not mix one locale's hydrated graph with another locale's
+messages. Add `data-sveltekit-reload` to every link that can cross locales;
+`setLocale()` already reloads by default.
+
 ```diff
 <script>
 	import { page } from '$app/state';
@@ -146,7 +168,11 @@ Then add a locale switcher in `routes/+layout.svelte` to generate all pages duri
 <slot></slot>
 ```
 
-If you use the static adapter with `ssr = false` (SPA mode), make asset paths absolute to avoid locale-prefixed 404s (see [paraglide-js#503](https://github.com/opral/paraglide-js/issues/503)):
+`experimentalPerLocaleBuild` does not support the static adapter's SPA fallback
+mode (`ssr = false` with a fallback page): one fallback document cannot select
+a locale-specific client graph. Use SSR or prerender every localized page. If
+you disable `experimentalPerLocaleBuild` and use SPA mode, make asset paths
+absolute to avoid locale-prefixed 404s (see [paraglide-js#503](https://github.com/opral/paraglide-js/issues/503)):
 
 ```diff
 // svelte.config.js
@@ -165,6 +191,9 @@ const config = {
 
 export default config;
 ```
+
+Non-default bundle strategies and SvelteKit service workers are not compatible
+with this experiment.
 
 ## Troubleshooting
 

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -7,6 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test": "node ./verify-per-locale-build.mjs",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write ."
@@ -15,13 +16,13 @@
 		"@inlang/paraglide-js": "workspace:*",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.49.4",
-		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"@sveltejs/kit": "~2.69.2",
+		"@sveltejs/vite-plugin-svelte": "^7.2.0",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.4.1",
-		"svelte": "^5.46.3",
+		"svelte": "^5.56.4",
 		"svelte-check": "^4.3.5",
 		"typescript": "^5.0.0",
-		"vite": "^7.3.1"
+		"vite": "^8.1.4"
 	}
 }

--- a/examples/sveltekit/src/routes/+layout.svelte
+++ b/examples/sveltekit/src/routes/+layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { locales, localizeHref } from '$lib/paraglide/runtime';
@@ -6,7 +6,10 @@
 
 <nav class="locale-switcher" aria-label="Languages">
 	{#each locales as locale}
-		<a href={resolve(localizeHref(page.url.pathname, { locale }))} data-sveltekit-reload>
+		<a
+			href={resolve(localizeHref(page.url.pathname, { locale }) as '/' | '/about')}
+			data-sveltekit-reload
+		>
 			{locale}
 		</a>
 	{/each}

--- a/examples/sveltekit/src/routes/+page.svelte
+++ b/examples/sveltekit/src/routes/+page.svelte
@@ -11,5 +11,5 @@
 
 <br />
 <br />
-<a href={resolve(localizeHref('/about', { locale: 'en' }))}>go to about in en</a>
-<a href={resolve(localizeHref('/about', { locale: 'de' }))}>go to about in de</a>
+<a href={resolve(localizeHref('/about', { locale: 'en' }) as '/about')} data-sveltekit-reload>go to about in en</a>
+<a href={resolve(localizeHref('/about', { locale: 'de' }) as '/about')} data-sveltekit-reload>go to about in de</a>

--- a/examples/sveltekit/src/routes/about/+page.svelte
+++ b/examples/sveltekit/src/routes/about/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { resolve } from '$app/paths';
 	import { localizeHref } from '$lib/paraglide/runtime';
 	import { m } from '$lib/paraglide/messages';
@@ -6,4 +6,4 @@
 
 <p>{m.about()}</p>
 
-<a href={resolve(localizeHref('/'))}>go back to home</a>
+<a href={resolve(localizeHref('/') as '/')}>go back to home</a>

--- a/examples/sveltekit/verify-per-locale-build.mjs
+++ b/examples/sveltekit/verify-per-locale-build.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const clientRoot = path.join(root, '.svelte-kit/output/client');
+const serverRoot = path.join(root, '.svelte-kit/output/server');
+const adapterRoot = path.join(root, 'build');
+const manifest = JSON.parse(
+	fs.readFileSync(path.join(clientRoot, 'paraglide-per-locale.json'), 'utf8')
+);
+const germanPrefix = '/_app/immutable/__paraglide/de-6465';
+
+assert.equal(manifest.version, 1);
+assert.equal(manifest.baseLocale, 'en');
+assert.equal(manifest.locales.en.prefix, '');
+assert.equal(manifest.locales.de.prefix, germanPrefix);
+
+for (const [canonicalUrl, localizedUrl] of Object.entries(manifest.locales.de.assets)) {
+	assert.ok(
+		fs.existsSync(path.join(clientRoot, localizedUrl.slice(1))),
+		`Missing mapped client asset ${localizedUrl} for ${canonicalUrl}`
+	);
+	if (localizedUrl.includes('/immutable/')) {
+		assert.ok(
+			fs.existsSync(path.join(adapterRoot, localizedUrl.slice(1))),
+			`The SvelteKit adapter did not copy ${localizedUrl}`
+		);
+	}
+}
+
+const canonicalClient = readFiles(
+	path.join(clientRoot, '_app/immutable'),
+	(file) => !file.includes(`${path.sep}__paraglide${path.sep}`)
+);
+const germanClient = readFiles(path.join(clientRoot, germanPrefix.slice(1)));
+const server = readFiles(serverRoot);
+
+const englishWelcome = 'Welcome to the SvelteKit Paraglide JS example.';
+const germanWelcome = 'Willkommen zum SvelteKit Paraglide JS Beispiel.';
+const unused = 'This is an unused message to verify tree-shaking.';
+assert.match(canonicalClient, new RegExp(escapeRegExp(englishWelcome)));
+assert.doesNotMatch(canonicalClient, new RegExp(escapeRegExp(germanWelcome)));
+assert.match(germanClient, new RegExp(escapeRegExp(germanWelcome)));
+assert.doesNotMatch(germanClient, new RegExp(escapeRegExp(englishWelcome)));
+assert.match(server, new RegExp(escapeRegExp(englishWelcome)));
+assert.match(server, new RegExp(escapeRegExp(germanWelcome)));
+assert.doesNotMatch(canonicalClient + germanClient, new RegExp(escapeRegExp(unused)));
+
+for (const relativeHtml of ['index.html', 'about.html']) {
+	assertHtmlUsesLocale(path.join(adapterRoot, relativeHtml), 'en');
+}
+for (const relativeHtml of ['de.html', 'de/about.html']) {
+	assertHtmlUsesLocale(path.join(adapterRoot, relativeHtml), 'de');
+}
+
+for (const file of listFiles(path.join(clientRoot, germanPrefix.slice(1)))) {
+	if (!file.endsWith('.js')) continue;
+	const code = fs.readFileSync(file, 'utf8');
+	for (const match of code.matchAll(/(?:\bfrom\s*|\bimport\s*\()\s*["']([^"']+)["']/g)) {
+		const specifier = match[1];
+		if (!specifier?.startsWith('.')) continue;
+		const resolved = path.resolve(path.dirname(file), specifier.replace(/[?#].*$/, ''));
+		assert.ok(fs.existsSync(resolved), `${path.relative(root, file)} imports missing ${specifier}`);
+	}
+}
+
+const [{ Server }, { manifest: fullManifest }] = await Promise.all([
+	import(pathToFileURL(path.join(serverRoot, 'index.js')).href),
+	import(pathToFileURL(path.join(serverRoot, 'manifest-full.js')).href)
+]);
+const serverApp = new Server(fullManifest);
+await serverApp.init({ env: {} });
+for (const [locale, pathname] of [
+	['en', '/'],
+	['de', '/de']
+]) {
+	const response = await serverApp.respond(
+		new Request(`http://paraglide.test${pathname}`, {
+			headers: { accept: 'text/html' }
+		}),
+		{ getClientAddress: () => '127.0.0.1' }
+	);
+	assert.equal(response.status, 200);
+	const html = await response.text();
+	const link = response.headers.get('link') ?? '';
+	if (locale === 'de') {
+		assert.ok(html.includes(germanPrefix), 'German SSR HTML is canonical');
+		assert.ok(link.includes(germanPrefix), 'German SSR Link header is canonical');
+	} else {
+		assert.ok(!html.includes('/__paraglide/'), 'English SSR HTML is localized');
+		assert.ok(!link.includes('/__paraglide/'), 'English SSR Link is localized');
+	}
+}
+
+console.log(
+	'SvelteKit per-locale build verified: isolated en/de clients, prerender and live-SSR asset selection, Link headers, shared server, and closed imports.'
+);
+
+function assertHtmlUsesLocale(file, locale) {
+	const html = fs.readFileSync(file, 'utf8');
+	const references = Array.from(
+		html.matchAll(/(?:href=|src=|import\()\s*["']([^"']+)["']/g),
+		(match) => match[1]
+	);
+	const immutableReferences = references.filter((reference) =>
+		reference.includes('_app/immutable/')
+	);
+	assert.ok(immutableReferences.length > 0, `No immutable assets in ${file}`);
+	for (const reference of immutableReferences) {
+		if (locale === 'de') {
+			assert.ok(
+				reference.includes('_app/immutable/__paraglide/de-6465/'),
+				`German page references the canonical graph: ${reference}`
+			);
+		} else {
+			assert.ok(
+				!reference.includes('/__paraglide/'),
+				`English page references a localized graph: ${reference}`
+			);
+		}
+	}
+	const favicon = references.find((reference) => reference.endsWith('favicon.png'));
+	assert.ok(favicon, `Missing favicon in ${file}`);
+	assert.ok(!favicon.includes('__paraglide'), `Public favicon was localized in ${file}`);
+}
+
+function readFiles(directory, include = () => true) {
+	return listFiles(directory)
+		.filter(include)
+		.map((file) => fs.readFileSync(file, 'utf8'))
+		.join('\n');
+}
+
+function listFiles(directory) {
+	const files = [];
+	for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+		const absolute = path.join(directory, entry.name);
+		if (entry.isDirectory()) files.push(...listFiles(absolute));
+		else files.push(absolute);
+	}
+	return files;
+}
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -3,14 +3,12 @@ import { defineConfig } from 'vite';
 import { paraglideVitePlugin } from '@inlang/paraglide-js';
 
 export default defineConfig({
-	build: {
-		minify: false
-	},
 	plugins: [
 		sveltekit(),
 		paraglideVitePlugin({
 			project: './project.inlang',
 			outdir: './src/lib/paraglide',
+			experimentalPerLocaleBuild: true,
 			strategy: ['url', 'cookie', 'baseLocale']
 		})
 	]

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -12,7 +12,7 @@ TanStack Router keeps owning your route tree, loaders, server functions, navigat
 This guide covers:
 
 - TanStack Router `rewrite` integration with `localizeUrl()` and `deLocalizeUrl()`
-- `paraglideMiddleware()` in the TanStack Start server entry
+- Generated request middleware and per-locale client asset selection
 - Locale-aware rendering in routes, loaders, and server functions
 - Type-safe translated pathnames from the generated TanStack route tree
 - Prerendering localized routes
@@ -48,7 +48,8 @@ export default defineConfig({
     react(),
 +              paraglideVitePlugin({
 +                      project: "./project.inlang",
-+                      outdir: "./app/paraglide",
++                      outdir: "./src/paraglide",
++                      experimentalPerLocaleBuild: true,
 +     outputStructure: "message-modules",
 +     cookieName: "PARAGLIDE_LOCALE",
 +     strategy: ["url", "cookie", "preferredLanguage", "baseLocale"],
@@ -65,7 +66,22 @@ export default defineConfig({
 });
 ```
 
-3. Done :)
+3. Re-export the generated TanStack Start server entry from `src/server.ts`:
+
+```ts
+export { default } from "./paraglide/tanstack-start.server.js";
+```
+
+The generated entry wraps TanStack Start with `paraglideMiddleware`, chooses the locale-specialized client assets before rendering, and preserves the page locale for server-function requests. TanStack Router still receives the original URL, so its `rewrite` configuration remains the only routing rewrite.
+
+This experimental path is deliberately fail-fast. It currently accepts Vite
+8.x with TanStack Start 1.168.x, root/default asset hosting, and a global
+strategy whose first entry is `url` or `cookie`. Do not configure
+`routeStrategies`, Vite `base`, source maps, `build.minify: false`, or
+`experimental.renderBuiltUrl`. Use the generated server entry rather than a
+custom `createStartHandler` or `transformAssets` pipeline.
+
+4. Done :)
 
 ## Usage
 
@@ -101,21 +117,9 @@ const router = createRouter({
 });
 ```
 
-In `server.ts` intercept the request with the paraglideMiddleware.
-
-> **Important:** Since TanStack Router handles URL localization/delocalization via its `rewrite` option, you must pass the original `req` to the handler instead of the modified `request` from the callback. Using the modified request would cause a redirect loop because both the middleware and the router would attempt to delocalize the URL. The middleware still handles locale detection, cookies, and AsyncLocalStorage context.
-
-```ts
-import { paraglideMiddleware } from './paraglide/server.js'
-import handler from '@tanstack/react-start/server-entry'
-export default {
-  fetch(req: Request): Promise<Response> {
-    // Pass original `req` - NOT the modified `request` from the callback
-    // TanStack Router handles URL rewriting via deLocalizeUrl/localizeUrl
-    return paraglideMiddleware(req, () => handler.fetch(req))
-  },
-}
-```
+Locale changes must use the default full-page navigation behavior of
+`setLocale()`; disabling reload would keep the old locale's specialized client
+graph active. Unsupported build configurations fail before assets are emitted.
 
 In `__root.tsx` change the HTML lang attribute to the current locale.
 

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -9,10 +9,10 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@tanstack/react-devtools": "^0.7.0",
-		"@tanstack/react-router": "1.145.7",
-		"@tanstack/react-router-devtools": "1.145.7",
-		"@tanstack/react-start": "1.145.7",
+		"@tanstack/react-devtools": "^0.10.8",
+		"@tanstack/react-router": "1.170.17",
+		"@tanstack/react-router-devtools": "1.167.0",
+		"@tanstack/react-start": "1.168.27",
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1"
 	},
@@ -21,11 +21,10 @@
 		"@types/node": "^22.18.6",
 		"@types/react": "^19.1.13",
 		"@types/react-dom": "^19.1.9",
-		"@vitejs/plugin-react": "^4.7.0",
+		"@vitejs/plugin-react": "^6.0.3",
 		"typescript": "^5.9.2",
-		"vite": "^7.1.7",
-		"vite-tsconfig-paths": "^5.1.4",
-		"@tailwindcss/vite": "^4.1.18",
-		"tailwindcss": "^4.1.18"
+		"vite": "^8.1.4",
+		"@tailwindcss/vite": "^4.3.2",
+		"tailwindcss": "^4.3.2"
 	}
 }

--- a/examples/tanstack-start/src/routes/index.tsx
+++ b/examples/tanstack-start/src/routes/index.tsx
@@ -4,7 +4,7 @@ import { getLocale } from '@/paraglide/runtime.js'
 import { createServerFn } from '@tanstack/react-start'
 
 const getServerMessage = createServerFn()
-  .inputValidator((emoji: string) => emoji)
+  .validator((emoji: string) => emoji)
   .handler((ctx) => {
     return m.server_message({ emoji: ctx.data })
   })

--- a/examples/tanstack-start/src/server.ts
+++ b/examples/tanstack-start/src/server.ts
@@ -1,8 +1,1 @@
-import { paraglideMiddleware } from "./paraglide/server.js";
-import handler from "@tanstack/react-start/server-entry";
-
-export default {
-	fetch(req: Request): Promise<Response> {
-		return paraglideMiddleware(req, () => handler.fetch(req));
-	},
-};
+export { default } from "./paraglide/tanstack-start.server.js";

--- a/examples/tanstack-start/vite.config.ts
+++ b/examples/tanstack-start/vite.config.ts
@@ -2,14 +2,17 @@ import { paraglideVitePlugin } from '@inlang/paraglide-js'
 import { defineConfig } from 'vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
-import viteTsConfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
 
 const config = defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
   plugins: [
     paraglideVitePlugin({
       project: './project.inlang',
       outdir: './src/paraglide',
+      experimentalPerLocaleBuild: true,
       outputStructure: 'message-modules',
       cookieName: 'PARAGLIDE_LOCALE',
       strategy: ['url', 'cookie', 'preferredLanguage', 'baseLocale'],
@@ -37,7 +40,6 @@ const config = defineConfig({
         },
       ],
     }),
-    viteTsConfigPaths(),
     tanstackStart(),
     viteReact(),
     tailwindcss(),

--- a/package.json
+++ b/package.json
@@ -57,10 +57,14 @@
 		"urlpattern-polyfill": "^10.0.0"
 	},
 	"peerDependencies": {
-		"typescript": ">=5.6"
+		"typescript": ">=5.6",
+		"vite": ">=5.0.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {
+			"optional": true
+		},
+		"vite": {
 			"optional": true
 		}
 	},
@@ -80,6 +84,7 @@
 		"typedoc-plugin-missing-exports": "4.0.0",
 		"typescript": "5.9.2",
 		"typescript-go": "npm:typescript@7.0.2",
+		"vite": "8.1.4",
 		"vitest": "3.1.4"
 	},
 	"keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       typescript-go:
         specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
+      vite:
+        specifier: 8.1.4
+        version: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 3.1.4
         version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
@@ -286,49 +289,49 @@ importers:
         version: link:../..
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
-        version: 7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 7.0.0(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 3.0.10(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@sveltejs/kit':
-        specifier: ^2.49.4
-        version: 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: ~2.69.2
+        version: 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^6.2.4
-        version: 6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: ^7.2.0
+        version: 7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       prettier:
         specifier: ^3.4.2
         version: 3.7.4
       prettier-plugin-svelte:
         specifier: ^3.4.1
-        version: 3.4.1(prettier@3.7.4)(svelte@5.46.3)
+        version: 3.4.1(prettier@3.7.4)(svelte@5.56.4)
       svelte:
-        specifier: ^5.46.3
-        version: 5.46.3
+        specifier: ^5.56.4
+        version: 5.56.4
       svelte-check:
         specifier: ^4.3.5
-        version: 4.3.5(picomatch@4.0.3)(svelte@5.46.3)(typescript@5.8.3)
+        version: 4.3.5(picomatch@4.0.3)(svelte@5.56.4)(typescript@5.8.3)
       typescript:
         specifier: ^5.0.0
         version: 5.8.3
       vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
   examples/tanstack-start:
     dependencies:
       '@tanstack/react-devtools':
-        specifier: ^0.7.0
-        version: 0.7.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)
+        specifier: ^0.10.8
+        version: 0.10.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)
       '@tanstack/react-router':
-        specifier: 1.145.7
-        version: 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 1.170.17
+        version: 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-router-devtools':
-        specifier: 1.145.7
-        version: 1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.145.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)
+        specifier: 1.167.0
+        version: 1.167.0(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.171.14)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
-        specifier: 1.145.7
-        version: 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: 1.168.27
+        version: 1.168.27(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       react:
         specifier: ^19.1.1
         version: 19.2.3
@@ -340,8 +343,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       '@tailwindcss/vite':
-        specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: ^4.3.2
+        version: 4.3.2(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/node':
         specifier: ^22.18.6
         version: 22.19.3
@@ -352,20 +355,17 @@ importers:
         specifier: ^19.1.9
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
-        specifier: ^4.7.0
-        version: 4.7.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       tailwindcss:
-        specifier: ^4.1.18
-        version: 4.1.18
+        specifier: ^4.3.2
+        version: 4.3.2
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
       vite:
-        specifier: ^7.1.7
-        version: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
   examples/vite:
     devDependencies:
@@ -410,7 +410,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   framework/solid:
     devDependencies:
@@ -428,7 +428,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   framework/svelte:
     dependencies:
@@ -444,13 +444,13 @@ importers:
         version: 4.3.0
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        version: 6.2.4(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   framework/vue:
     devDependencies:
@@ -468,7 +468,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
       vue:
         specifier: ^3.5.13
         version: 3.5.27(typescript@5.8.3)
@@ -538,7 +538,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: 3.1.4
-        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -918,8 +918,14 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
@@ -929,6 +935,9 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -1547,89 +1556,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1775,6 +1800,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1817,6 +1848,9 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
   '@oxlint/darwin-arm64@1.36.0':
     resolution: {integrity: sha512-MJkj82GH+nhvWKJhSIM6KlZ8tyGKdogSQXtNdpIyP02r/tTayFJQaAEWayG2Jhsn93kske+nimg5MYFhwO/rlg==}
     cpu: [arm64]
@@ -1831,21 +1865,25 @@ packages:
     resolution: {integrity: sha512-EMx92X5q+hHc3olTuj/kgkx9+yP0p/AVs4yvHbUfzZhBekXNpUWxWvg4hIKmQWn+Ee2j4o80/0ACGO0hDYJ9mg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.36.0':
     resolution: {integrity: sha512-7YCxtrPIctVYLqWrWkk8pahdCxch6PtsaucfMLC7TOlDt4nODhnQd4yzEscKqJ8Gjrw1bF4g+Ngob1gB+Qr9Fw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.36.0':
     resolution: {integrity: sha512-lnaJVlx5r3NWmoOMesfQXJSf78jHTn8Z+sdAf795Kgteo72+qGC1Uax2SToCJVN2J8PNG3oRV5bLriiCNR2i6Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.36.0':
     resolution: {integrity: sha512-AhuEU2Qdl66lSfTGu/Htirq8r/8q2YnZoG3yEXLMQWnPMn7efy8spD/N1NA7kH0Hll+cdfwgQkQqC2G4MS2lPQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.36.0':
     resolution: {integrity: sha512-GlWCBjUJY2QgvBFuNRkiRJu7K/djLmM0UQKfZV8IN+UXbP/JbjZHWKRdd4LXlQmzoz7M5Hd6p+ElCej8/90FCg==}
@@ -2210,8 +2248,20 @@ packages:
   '@remix-run/node-fetch-server@0.9.0':
     resolution: {integrity: sha512-SoLMv7dbH+njWzXnOY6fI08dFMI5+/dQ+vY3n8RnnbdG7MdJEgiP28Xj/xWlnRnED/aB6SFw56Zop+LbmaaKqA==}
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.1':
     resolution: {integrity: sha512-e4QpTp7eu61JilK958i21RK/HniwVLjZgfShqoQY1VM+KDYz90cNuopKQ3Z3oCkvyAN3xI8IaRhy02nlxdR/DA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
@@ -2220,8 +2270,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.1':
     resolution: {integrity: sha512-ZP9Q1q4IfvJ8dfWTHOF3cquNpAKuQQ+kZJQTxo85fGnKqtqMWFNouaBVd79pqCxU3w4oIjuZ8o55qNDomMTbVA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
@@ -2230,33 +2292,102 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.1':
     resolution: {integrity: sha512-xkGD+YLH+vQZiqxKEsXe8xS/owQXkyARaNB9NfFrAacLoNIRZM5UEZGNKxXyRWd1kSEkYkJ3/WiqvGGCcqUg1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.1':
     resolution: {integrity: sha512-Ey2UxKFL74JuWpdNl9stpV0kxHZIgCWCEUnDnpQ1hcBwO9KwDM5qicLtXfsjozD6vt+xzbrL2D/uTrziYZ7IDQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.1':
     resolution: {integrity: sha512-a8QP35x/3mggWqCpFtaF3/PbWl5P9QKpP/muk3iMPgzrXto8zPsEl3imsP3EBh4KwanBVHIf8pEkBQ+/7iMTgQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.1':
     resolution: {integrity: sha512-uIqKwnkZjTY8FmqGMaSjwtWlCdV88LV9bjdkv+mb7I+BBw+9cJlIQy0P8YnGEOEcnDPis/SiraCpkJ/eHYaSZw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.1':
     resolution: {integrity: sha512-RB+gbhwZtTbKbvHzUcaRFva2ONCUTuxDEb/b3/rd3O82OTPUZzOY24mqreiXH1XG09p6WFXSE8dzUrN120Q29w==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.1':
     resolution: {integrity: sha512-NSccQD7+9vhEfDMc8HyODuUU1jLYEsEiICc1zwmbeg0FXx1pwpFpZZQby4bAMnK2obav7D9FfsruYWodhNdIqQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
@@ -2270,6 +2401,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -2278,6 +2415,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
@@ -2361,121 +2501,145 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -2605,6 +2769,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.11':
+    resolution: {integrity: sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@sveltejs/acorn-typescript@1.0.8':
     resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
     peerDependencies:
@@ -2620,16 +2789,16 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.49.4':
-    resolution: {integrity: sha512-JFtOqDoU0DI/+QSG8qnq5bKcehVb3tCHhOG4amsSYth5/KgO4EkJvi42xSAiyKmXAAULW1/Zdb6lkgGEgSxdZg==}
+  '@sveltejs/kit@2.69.2':
+    resolution: {integrity: sha512-CMdPDbYjRwRu4KXTxBVMuOpFPCt1i/v0ANennotec+K9Cmb2e3w2yYzJiC6Vh/WSvm9Khi5sJMZa0rJPqfHlDw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
-      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      typescript: ^5.3.3
-      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
@@ -2666,12 +2835,28 @@ packages:
       svelte: ^5.0.0
       vite: ^6.3.0 || ^7.0.0
 
+  '@sveltejs/vite-plugin-svelte@7.2.0':
+    resolution: {integrity: sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
+
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
+
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
   '@tailwindcss/oxide-android-arm64@4.1.18':
     resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
     engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
@@ -2681,9 +2866,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-x64@4.1.18':
     resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
@@ -2693,9 +2890,21 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
     resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
     engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
@@ -2704,27 +2913,71 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -2741,9 +2994,21 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
   '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
     resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
@@ -2751,32 +3016,43 @@ packages:
     resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
     engines: {node: '>= 10'}
 
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
   '@tailwindcss/vite@4.1.18':
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  '@tanstack/devtools-client@0.0.3':
-    resolution: {integrity: sha512-kl0r6N5iIL3t9gGDRAv55VRM3UIyMKVH83esRGq7xBjYsRLe/BeCIN2HqrlJkObUXQMKhy7i8ejuGOn+bDqDBw==}
+  '@tailwindcss/vite@4.3.2':
+    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/devtools-client@0.0.8':
+    resolution: {integrity: sha512-cG3iZkGWCwN330bLBKa8+9r4Of2AXNoz2zUqcsy/4XsD3105ghVBx78cGyvJj9fSclNomPxoqAnDGXXhg1WLvA==}
     engines: {node: '>=18'}
 
-  '@tanstack/devtools-event-bus@0.3.3':
-    resolution: {integrity: sha512-lWl88uLAz7ZhwNdLH6A3tBOSEuBCrvnY9Fzr5JPdzJRFdM5ZFdyNWz1Bf5l/F3GU57VodrN0KCFi9OA26H5Kpg==}
+  '@tanstack/devtools-event-bus@0.4.2':
+    resolution: {integrity: sha512-2LHzhwBFlKHCcklsQrGe8TeyjHd4XAF8nuCO6wHmva5fePUkJUULbu6CsCNAlGlCi0KkEsMXZSvRdR4HgMq4yA==}
     engines: {node: '>=18'}
 
-  '@tanstack/devtools-event-client@0.3.5':
-    resolution: {integrity: sha512-RL1f5ZlfZMpghrCIdzl6mLOFLTuhqmPNblZgBaeKfdtk5rfbjykurv+VfYydOFXj0vxVIoA2d/zT7xfD7Ph8fw==}
+  '@tanstack/devtools-event-client@0.5.0':
+    resolution: {integrity: sha512-H+OH3zC6Vhu/K0NaVfQKknEKawc/+2PT+D3SB3Ox0V8SiMlTo0abbmH2rH0721R2aNYbjdMXA1oENOd8E2UVoA==}
     engines: {node: '>=18'}
+    hasBin: true
 
-  '@tanstack/devtools-ui@0.4.4':
-    resolution: {integrity: sha512-5xHXFyX3nom0UaNfiOM92o6ziaHjGo3mcSGe2HD5Xs8dWRZNpdZ0Smd0B9ddEhy0oB+gXyMzZgUJb9DmrZV0Mg==}
+  '@tanstack/devtools-ui@0.6.0':
+    resolution: {integrity: sha512-CVaM6rT6Nl5ijo83vJYFa2SjofvpuOl/uOvbYGhBrRgUhhelNHhx8zZX+hnZCHmIr0/lzM65hsocnZ72592Rvg==}
     engines: {node: '>=18'}
     peerDependencies:
       solid-js: '>=1.9.7'
 
-  '@tanstack/devtools@0.7.0':
-    resolution: {integrity: sha512-AlAoCqJhWLg9GBEaoV1g/j+X/WA1aJSWOsekxeuZpYeS2hdVuKAjj04KQLUMJhtLfNl2s2E+TCj7ZRtWyY3U4w==}
+  '@tanstack/devtools@0.12.5':
+    resolution: {integrity: sha512-JdxTSeVdjJheycgz4c7qbldNKDCEDWlWr1l9dZBhd9sOmRBT5Z70ka9Eb8mb+FUnalcOIB62IDSR/iSxAIUD8Q==}
     engines: {node: '>=18'}
+    hasBin: true
     peerDependencies:
       solid-js: '>=1.9.7'
 
@@ -2784,11 +3060,15 @@ packages:
     resolution: {integrity: sha512-gMo/ReTUp0a3IOcZoI3hH6PLDC2R/5ELQ7P2yu9F6aEkA0wSQh+Q4qzMrtcKvF2ut0oE+16xWCGDo/TdYd6cEQ==}
     engines: {node: '>=12'}
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/query-core@5.101.0':
     resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
 
-  '@tanstack/react-devtools@0.7.11':
-    resolution: {integrity: sha512-a2Lmz8x+JoDrsU6f7uKRcyyY+k8mA/n5mb9h7XJ3Fz/y3+sPV9t7vAW1s5lyNkQyyDt6V1Oim99faLthoJSxMw==}
+  '@tanstack/react-devtools@0.10.8':
+    resolution: {integrity: sha512-YJV6YttQf9lhhPbPBLULgy1eScEvJUMsCS26mjg9hfBKgAJQA5sF9zvzorDzW9Ob6o/asoXikO81JnRUVuFX0Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/react': '>=16.8'
@@ -2801,12 +3081,12 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-router-devtools@1.145.7':
-    resolution: {integrity: sha512-crzHSQ/rcGX7RfuYsmm1XG5quurNMDTIApU7jfwDx5J9HnUxCOSJrbFX0L3w0o0VRCw5xhrL2EdCnW78Ic86hg==}
-    engines: {node: '>=12'}
+  '@tanstack/react-router-devtools@1.167.0':
+    resolution: {integrity: sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w==}
+    engines: {node: '>=20.19'}
     peerDependencies:
-      '@tanstack/react-router': ^1.145.7
-      '@tanstack/router-core': ^1.145.7
+      '@tanstack/react-router': ^1.170.0
+      '@tanstack/router-core': ^1.170.0
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
     peerDependenciesMeta:
@@ -2830,6 +3110,13 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
+  '@tanstack/react-router@1.170.17':
+    resolution: {integrity: sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
   '@tanstack/react-start-client@1.145.7':
     resolution: {integrity: sha512-CfJYE77Yilal0VKWw2aZxzg4Zlh7/egfp46bgM6cPrEiC3PZl01hmoyot7saZKs22Ifc6uhFcsblAByQDVNW+Q==}
     engines: {node: '>=22.12.0'}
@@ -2837,8 +3124,39 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
+  '@tanstack/react-start-client@1.168.15':
+    resolution: {integrity: sha512-pW50PHvadgi50iNCw6deUOvqc9rzs30SstyFZY2tcS9z1XlqTlELSvGowjxdu2m0ymtqm1emj1jau1iP7+3+PQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-rsc@0.1.26':
+    resolution: {integrity: sha512-+FMm3qtT1gWsl0i5sG/Q70mh1k7tzZUsPBaqbg4v34zVJZ+XGn1mJb34x2w7z1M0/e7co6GkZfV8BRpczrs8UA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rspack/core': '>=2.0.0-0'
+      '@vitejs/plugin-rsc': '>=0.5.20'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      react-server-dom-rspack: '>=0.0.2'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      react-server-dom-rspack:
+        optional: true
+
   '@tanstack/react-start-server@1.145.7':
     resolution: {integrity: sha512-lQJgUAtKY8P1LNfv/lUVOQdLMuGEz6bVd2O/4ljIpYDNxzqLe+embcnZu+/tlv5km3sbxPlZc+AhykZyZphVVg==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-server@1.167.21':
+    resolution: {integrity: sha512-puJ7eFxaLuDzeM/tiLDJaXCA4uK+PZnEOoIC73zipsFqx865MGzrRS/GSZxeVxjavC5iHU+ZwC+rgI0qYSol1A==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       react: '>=18.0.0 || >=19.0.0'
@@ -2852,8 +3170,31 @@ packages:
       react-dom: '>=18.0.0 || >=19.0.0'
       vite: '>=7.0.0'
 
+  '@tanstack/react-start@1.168.27':
+    resolution: {integrity: sha512-rdGFDqfCW71gyofyAxaYxhelNKmeVjpmbpm0uFYbNHORCa///4aBxi7B7ecShibKv9O4GfJ66MPX5F0ozbm+ig==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      '@vitejs/plugin-rsc': '*'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      vite:
+        optional: true
+
   '@tanstack/react-store@0.8.0':
     resolution: {integrity: sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2862,13 +3203,16 @@ packages:
     resolution: {integrity: sha512-v6jx6JqVUBM0/FcBq1tX22xiPq8Ufc0PDEP582/4deYoq2/RYd+bZstANp3mGSsqdxE/luhoLYuuSQiwi/j1wA==}
     engines: {node: '>=12'}
 
-  '@tanstack/router-devtools-core@1.145.7':
-    resolution: {integrity: sha512-oKeq/6QvN49THCh++FJyPv1X65i20qGS4aJHQTNsl4cu1piW1zWUhab2L3DZVr3G8C40FW3xb6hVw92N/fzZbQ==}
-    engines: {node: '>=12'}
+  '@tanstack/router-core@1.171.14':
+    resolution: {integrity: sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/router-devtools-core@1.168.0':
+    resolution: {integrity: sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg==}
+    engines: {node: '>=20.19'}
     peerDependencies:
-      '@tanstack/router-core': ^1.145.7
+      '@tanstack/router-core': ^1.170.0
       csstype: ^3.0.10
-      solid-js: '>=1.9.5'
     peerDependenciesMeta:
       csstype:
         optional: true
@@ -2876,6 +3220,10 @@ packages:
   '@tanstack/router-generator@1.145.7':
     resolution: {integrity: sha512-xg71c1WTku0ro0rgpJWh3Dt+ognV9qWe2KJHAPzrqfOYdUYu9sGq7Ri4jo8Rk0luXWZrWsrFdBP+9Jx6JH6zWA==}
     engines: {node: '>=12'}
+
+  '@tanstack/router-generator@1.167.18':
+    resolution: {integrity: sha512-kFvM4caRds9Q3EXg64bZubJ6rbDxyV0YDSBSGvOGzmKspQPdz5Xrh0uj5T1Ov8avUUg+c761u04VQAaEzSBXRw==}
+    engines: {node: '>=20.19'}
 
   '@tanstack/router-plugin@1.145.7':
     resolution: {integrity: sha512-Rimo0NragYKHwjoYX9JBLS8VkZD4D/LqzzLIlX9yz93lmWFRu/DbuS7fDZNqX1Ea8naNvo18DlySszYLzC8XDg==}
@@ -2885,6 +3233,27 @@ packages:
       '@tanstack/react-router': ^1.145.7
       vite: '>=5.0.0 || >=6.0.0 || >=7.0.0'
       vite-plugin-solid: ^2.11.10
+      webpack: '>=5.92.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      vite:
+        optional: true
+      vite-plugin-solid:
+        optional: true
+      webpack:
+        optional: true
+
+  '@tanstack/router-plugin@1.168.19':
+    resolution: {integrity: sha512-aFglwLc+bbPTgZlkXn3PvOwpjJAfgUyPGSuql4MP3XrqTTh6WkBiy2RYb6oaG5h0s7EKwivEuq85K3Y4V0Mt1g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
+      '@tanstack/react-router': ^1.170.17
+      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
+      vite-plugin-solid: ^2.11.10 || ^3.0.0-0
       webpack: '>=5.92.0'
     peerDependenciesMeta:
       '@rsbuild/core':
@@ -2909,12 +3278,24 @@ packages:
     resolution: {integrity: sha512-N24G4LpfyK8dOlnP8BvNdkuxg1xQljkyl6PcrdiPSA301pOjatRT1y8wuCCJZKVVD8gkd0MpCZ0VEjRMGILOtA==}
     engines: {node: '>=12'}
 
+  '@tanstack/router-utils@1.162.2':
+    resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/start-client-core@1.145.7':
     resolution: {integrity: sha512-SjmHFU3xSXn32GNAdbD8z8n4fPmeQgBVQqx+1Uq0qlONrSEnnLdtxdjk9zXAO27Gdylj6IWlVeFNp7e9/VdVtw==}
     engines: {node: '>=22.12.0'}
 
+  '@tanstack/start-client-core@1.170.13':
+    resolution: {integrity: sha512-o37M3msIK5ec87kPrIYJWXb1XPnjIe5/jrkGLXiXpFuVL99z7mhoBCzftKtVPtzqI8EElnRE/VGFYT9BHNnWcw==}
+    engines: {node: '>=22.12.0'}
+
   '@tanstack/start-fn-stubs@1.143.8':
     resolution: {integrity: sha512-2IKUPh/TlxwzwHMiHNeFw95+L2sD4M03Es27SxMR0A60Qc4WclpaD6gpC8FsbuNASM2jBxk2UyeYClJxW1GOAQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-fn-stubs@1.162.0':
+    resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/start-plugin-core@1.145.7':
@@ -2923,20 +3304,47 @@ packages:
     peerDependencies:
       vite: '>=7.0.0'
 
+  '@tanstack/start-plugin-core@1.171.19':
+    resolution: {integrity: sha512-+fpW3Z/2vPT8HDV1c5p2WC6/g2k/AV/ujdJVDcn/VFd+gXRtzSX1D/LfozlaDbhDoEsqOnAk/mGwjg60JkUA2Q==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      vite:
+        optional: true
+
   '@tanstack/start-server-core@1.145.7':
     resolution: {integrity: sha512-pKPX7sLVyraH0qo6/eZLxIhXiBVZhhioxf1uzp/XovkXJK54bee5sbxDaVyHqpq8kwN1qfLeJSoSDlOK/CTGQg==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-server-core@1.169.16':
+    resolution: {integrity: sha512-lvAjQpH3nHJtd4xy0iHIaWbsTbyN9EBxuYCxbtXH0EpeBQPg+TCPhu9GQC9WbbA1rE//s82CpE55oYDQMqkU5A==}
     engines: {node: '>=22.12.0'}
 
   '@tanstack/start-storage-context@1.145.7':
     resolution: {integrity: sha512-YTYaeEyO6ADPoQAnkPDgmRKPpem0yaETJmcIyblTPqXaYubPSQmZTzoP+guXoSTOPo51tkiMXt+PzBHY+QbBFA==}
     engines: {node: '>=22.12.0'}
 
+  '@tanstack/start-storage-context@1.167.16':
+    resolution: {integrity: sha512-zTegxlij4BC1DbCrC6rsVlMOQVMzOuG5IllacZEkrUdhiFwMIMYpk0VWGH+d0ucx5RBkmv8e8GNX3AOVBWclfg==}
+    engines: {node: '>=22.12.0'}
+
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@tanstack/virtual-file-routes@1.145.4':
     resolution: {integrity: sha512-CI75JrfqSluhdGwLssgVeQBaCphgfkMQpi8MCY3UJX1hoGzXa8kHYJcUuIFMOLs1q7zqHy++EVVtMK03osR5wQ==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-file-routes@1.162.0':
+    resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
+    engines: {node: '>=20.19'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2965,6 +3373,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3282,6 +3693,19 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
   '@vitest/coverage-v8@3.1.4':
     resolution: {integrity: sha512-G4p6OtioySL+hPV7Y6JHlhpsODbJzt1ndwHAFkyk6vVjpK03PFsKnauZIzcd0PrK4zAbc5lc+jeZ+eNGiMA+iw==}
     peerDependencies:
@@ -3370,6 +3794,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3428,6 +3857,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -3464,6 +3897,9 @@ packages:
 
   babel-dead-code-elimination@1.0.11:
     resolution: {integrity: sha512-mwq3W3e/pKSI6TG8lXMiDWvEi1VXYlSBlJlB3l+I0bAb5u1RNUl88udos85eOPNK3m5EXK9uO7d2g08pesTySQ==}
+
+  babel-dead-code-elimination@1.0.12:
+    resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
   babel-plugin-jsx-dom-expressions@0.40.6:
     resolution: {integrity: sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==}
@@ -3638,6 +4074,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -3738,6 +4178,9 @@ packages:
 
   cookie-es@2.0.0:
     resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -4077,6 +4520,9 @@ packages:
   devalue@5.6.1:
     resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
 
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -4160,6 +4606,10 @@ packages:
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -4285,6 +4735,14 @@ packages:
   esrap@2.2.1:
     resolution: {integrity: sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==}
 
+  esrap@2.2.13:
+    resolution: {integrity: sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -4358,6 +4816,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetchdts@0.1.7:
+    resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4536,6 +4997,16 @@ packages:
 
   h3@1.15.4:
     resolution: {integrity: sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==}
+
+  h3@2.0.1-rc.20:
+    resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
 
   h3@2.0.1-rc.7:
     resolution: {integrity: sha512-qbrRu1OLXmUYnysWOCVrYhtC/m8ZuXu/zCbo3U/KyphJxbPFiC76jHYwVrmEcss9uNAHO5BoUguQ46yEpgI2PA==}
@@ -4835,6 +5306,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
@@ -4942,8 +5417,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -4954,8 +5441,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -4966,32 +5465,76 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -5002,8 +5545,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -5330,6 +5883,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5565,6 +6123,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -5587,6 +6149,10 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -5796,6 +6362,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -5906,6 +6476,11 @@ packages:
       '@babel/runtime':
         optional: true
 
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.54.0:
     resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5918,6 +6493,9 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -5987,12 +6565,22 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.5:
+    resolution: {integrity: sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.3.2:
     resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
     engines: {node: '>=10'}
 
   seroval@1.4.2:
     resolution: {integrity: sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==}
+    engines: {node: '>=10'}
+
+  seroval@1.5.5:
+    resolution: {integrity: sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==}
     engines: {node: '>=10'}
 
   serve-static@1.16.3:
@@ -6004,6 +6592,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -6112,6 +6703,11 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  srvx@0.11.21:
+    resolution: {integrity: sha512-GWTHjKMeekX8CwJf4VU9Oo6mJpSGaflGMddbCvR+Cmmh9sslRMiGbAoqqZacE0r1ncARh6buCEETr2W52F8b1w==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -6192,6 +6788,10 @@ packages:
     resolution: {integrity: sha512-Y5juST3x+/ySty5tYJCVWa6Corkxpt25bUZQHqOceg9xfMUtDsFx6rCsG6cYf1cA6vzDi66HIvaki0byZZX95A==}
     engines: {node: '>=18'}
 
+  svelte@5.56.4:
+    resolution: {integrity: sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==}
+    engines: {node: '>=18'}
+
   svgo@4.0.0:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
@@ -6203,8 +6803,15 @@ packages:
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   term-size@2.2.1:
@@ -6242,6 +6849,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -6308,6 +6919,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -6448,6 +7060,39 @@ packages:
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unstorage@1.17.3:
     resolution: {integrity: sha512-i+JYyy0DoKmQ3FximTHbGadmIYb8JEpq7lxUjnjeB702bCPum0vzo6oy5Mfu0lpqISw7hCyMW2yj4nWC8bqJ3Q==}
@@ -6616,14 +7261,6 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
 
-  vite-tsconfig-paths@5.1.4:
-    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
-
   vite-tsconfig-paths@6.1.1:
     resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
     peerDependencies:
@@ -6700,8 +7337,8 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.0:
-    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6740,15 +7377,16 @@ packages:
       yaml:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@8.1.4:
+    resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -6759,11 +7397,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -6981,6 +7621,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7167,7 +7810,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -7193,7 +7836,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -7202,8 +7845,8 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7215,7 +7858,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7246,7 +7889,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
@@ -7257,14 +7900,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7602,9 +8245,20 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -7619,6 +8273,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8292,6 +8951,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8346,6 +9012,8 @@ snapshots:
       - supports-color
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@oxc-project/types@0.139.0': {}
 
   '@oxlint/darwin-arm64@1.36.0':
     optional: true
@@ -8719,28 +9387,64 @@ snapshots:
 
   '@remix-run/node-fetch-server@0.9.0': {}
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.0-beta.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-beta.1':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.0-beta.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.1':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.1':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.1':
     optional: true
 
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.1':
@@ -8748,7 +9452,17 @@ snapshots:
       '@napi-rs/wasm-runtime': 0.2.12
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.1':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
   '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.1':
@@ -8757,11 +9471,16 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.1':
     optional: true
 
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-beta.40': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-virtual@3.0.2(rollup@4.55.1)':
     optionalDependencies:
@@ -9007,36 +9726,43 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.15.0)':
+    dependencies:
+      acorn: 8.15.0
+
+  '@sveltejs/acorn-typescript@1.0.11(acorn@8.17.0)':
+    dependencies:
+      acorn: 8.17.0
+
   '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@7.0.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@sveltejs/adapter-auto@7.0.0(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/kit': 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@sveltejs/kit': 2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/kit': 2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/kit@2.69.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.56.4)(typescript@5.8.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
+      '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/cookie': 0.6.0
-      acorn: 8.15.0
+      acorn: 8.17.0
       cookie: 0.6.0
-      devalue: 5.6.1
+      devalue: 5.8.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
       mrmime: 2.0.1
-      sade: 1.8.1
-      set-cookie-parser: 2.7.2
+      set-cookie-parser: 3.1.2
       sirv: 3.0.2
-      svelte: 5.46.3
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      svelte: 5.56.4
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -9049,12 +9775,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       obug: 2.1.1
       svelte: 5.46.3
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.46.1)(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -9069,15 +9795,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.46.3)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.46.3
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.1(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+
+  '@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.4)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      deepmerge: 4.3.1
+      magic-string: 0.30.21
+      obug: 2.1.1
+      svelte: 5.56.4
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.3(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -9089,40 +9824,86 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.1.18
 
+  '@tailwindcss/node@4.3.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
   '@tailwindcss/oxide-android-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.1.18':
     optional: true
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.1.18':
     optional: true
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     optional: true
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
     optional: true
 
   '@tailwindcss/oxide@4.1.18':
@@ -9140,19 +9921,27 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
   '@tailwindcss/vite@4.1.18(vite@5.4.21(@types/node@20.19.27)(lightningcss@1.30.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 5.4.21(@types/node@20.19.27)(lightningcss@1.30.2)
-
-  '@tailwindcss/vite@4.1.18(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@tailwindcss/node': 4.1.18
-      '@tailwindcss/oxide': 4.1.18
-      tailwindcss: 4.1.18
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -9161,35 +9950,43 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@tanstack/devtools-client@0.0.3':
+  '@tailwindcss/vite@4.3.2(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@tanstack/devtools-event-client': 0.3.5
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      tailwindcss: 4.3.2
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@tanstack/devtools-event-bus@0.3.3':
+  '@tanstack/devtools-client@0.0.8':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.5.0
+
+  '@tanstack/devtools-event-bus@0.4.2':
     dependencies:
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@tanstack/devtools-event-client@0.3.5': {}
+  '@tanstack/devtools-event-client@0.5.0': {}
 
-  '@tanstack/devtools-ui@0.4.4(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/devtools-ui@0.6.0(csstype@3.2.3)(solid-js@1.9.10)':
     dependencies:
       clsx: 2.1.1
+      dayjs: 1.11.21
       goober: 2.1.18(csstype@3.2.3)
       solid-js: 1.9.10
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools@0.7.0(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/devtools@0.12.5(csstype@3.2.3)(solid-js@1.9.10)':
     dependencies:
       '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.10)
       '@solid-primitives/keyboard': 1.3.3(solid-js@1.9.10)
       '@solid-primitives/resize-observer': 2.1.3(solid-js@1.9.10)
-      '@tanstack/devtools-client': 0.0.3
-      '@tanstack/devtools-event-bus': 0.3.3
-      '@tanstack/devtools-ui': 0.4.4(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/devtools-client': 0.0.8
+      '@tanstack/devtools-event-bus': 0.4.2
+      '@tanstack/devtools-ui': 0.6.0(csstype@3.2.3)(solid-js@1.9.10)
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
       solid-js: 1.9.10
@@ -9200,11 +9997,13 @@ snapshots:
 
   '@tanstack/history@1.145.7': {}
 
+  '@tanstack/history@1.162.0': {}
+
   '@tanstack/query-core@5.101.0': {}
 
-  '@tanstack/react-devtools@0.7.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)':
+  '@tanstack/react-devtools@0.10.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)':
     dependencies:
-      '@tanstack/devtools': 0.7.0(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/devtools': 0.12.5(csstype@3.2.3)(solid-js@1.9.10)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.3
@@ -9220,17 +10019,16 @@ snapshots:
       '@tanstack/query-core': 5.101.0
       react: 19.2.3
 
-  '@tanstack/react-router-devtools@1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.145.7)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)':
+  '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.171.14)(csstype@3.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/react-router': 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/router-devtools-core': 1.145.7(@tanstack/router-core@1.145.7)(csstype@3.2.3)(solid-js@1.9.10)
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-devtools-core': 1.168.0(@tanstack/router-core@1.171.14)(csstype@3.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
-      '@tanstack/router-core': 1.145.7
+      '@tanstack/router-core': 1.171.14
     transitivePeerDependencies:
       - csstype
-      - solid-js
 
   '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.3))(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.145.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -9254,6 +10052,15 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
+  '@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-core': 1.171.14
+      isbot: 5.1.32
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@tanstack/react-start-client@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/react-router': 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -9263,6 +10070,41 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
+
+  '@tanstack/react-start-client@1.168.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-client-core': 1.170.13
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/react-start-rsc@0.1.26(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.13
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/start-server-core': 1.169.16
+      '@tanstack/start-storage-context': 1.167.16
+      pathe: 2.0.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rsbuild/core'
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite
+      - vite-plugin-solid
+      - webpack
 
   '@tanstack/react-start-server@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -9276,25 +10118,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/react-start-server@1.167.21(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/react-router': 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-client': 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/react-start-server': 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@tanstack/router-utils': 1.143.11
-      '@tanstack/start-client-core': 1.145.7
-      '@tanstack/start-plugin-core': 1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      '@tanstack/start-server-core': 1.145.7
-      pathe: 2.0.3
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-server-core': 1.169.16
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
-      - '@rsbuild/core'
       - crossws
-      - supports-color
-      - vite-plugin-solid
-      - webpack
 
   '@tanstack/react-start@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -9316,9 +10148,45 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
+  '@tanstack/react-start@1.168.27(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-start-client': 1.168.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-start-rsc': 0.1.26(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/react-start-server': 1.167.21(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.13
+      '@tanstack/start-plugin-core': 1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/start-server-core': 1.169.16
+      pathe: 2.0.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - react-server-dom-rspack
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+      - vite-plugin-solid
+      - webpack
+
   '@tanstack/react-store@0.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/store': 0.8.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      use-sync-external-store: 1.6.0(react@19.2.3)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/store': 0.9.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
@@ -9333,13 +10201,18 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/router-devtools-core@1.145.7(@tanstack/router-core@1.145.7)(csstype@3.2.3)(solid-js@1.9.10)':
+  '@tanstack/router-core@1.171.14':
     dependencies:
-      '@tanstack/router-core': 1.145.7
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.5
+      seroval-plugins: 1.5.5(seroval@1.5.5)
+
+  '@tanstack/router-devtools-core@1.168.0(@tanstack/router-core@1.171.14)(csstype@3.2.3)':
+    dependencies:
+      '@tanstack/router-core': 1.171.14
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.2.3)
-      solid-js: 1.9.10
-      tiny-invariant: 1.3.3
     optionalDependencies:
       csstype: 3.2.3
 
@@ -9356,26 +10229,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tanstack/router-generator@1.167.18':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@tanstack/router-core': 1.145.7
-      '@tanstack/router-generator': 1.145.7
-      '@tanstack/router-utils': 1.143.11
-      '@tanstack/virtual-file-routes': 1.145.4
-      babel-dead-code-elimination: 1.0.11
-      chokidar: 3.6.0
-      unplugin: 2.3.11
-      zod: 3.25.76
-    optionalDependencies:
-      '@tanstack/react-router': 1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/virtual-file-routes': 1.162.0
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      prettier: 3.7.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9402,6 +10265,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-generator': 1.167.18
+      '@tanstack/router-utils': 1.162.2
+      chokidar: 5.0.0
+      unplugin: 3.3.0(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+      zod: 4.4.3
+    optionalDependencies:
+      '@tanstack/react-router': 1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+
   '@tanstack/router-ssr-query-core@1.169.1(@tanstack/query-core@5.101.0)(@tanstack/router-core@1.145.7)':
     dependencies:
       '@tanstack/query-core': 5.101.0
@@ -9419,6 +10307,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/router-utils@1.162.2':
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      ansis: 4.2.0
+      babel-dead-code-elimination: 1.0.12
+      diff: 8.0.2
+      pathe: 2.0.3
+      tinyglobby: 0.2.15
+    transitivePeerDependencies:
+      - supports-color
+
   '@tanstack/start-client-core@1.145.7':
     dependencies:
       '@tanstack/router-core': 1.145.7
@@ -9428,38 +10329,16 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
+  '@tanstack/start-client-core@1.170.13':
+    dependencies:
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-storage-context': 1.167.16
+      seroval: 1.5.5
+
   '@tanstack/start-fn-stubs@1.143.8': {}
 
-  '@tanstack/start-plugin-core@1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/core': 7.28.5
-      '@babel/types': 7.28.5
-      '@rolldown/pluginutils': 1.0.0-beta.40
-      '@tanstack/router-core': 1.145.7
-      '@tanstack/router-generator': 1.145.7
-      '@tanstack/router-plugin': 1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      '@tanstack/router-utils': 1.143.11
-      '@tanstack/start-client-core': 1.145.7
-      '@tanstack/start-server-core': 1.145.7
-      babel-dead-code-elimination: 1.0.11
-      cheerio: 1.1.2
-      exsolve: 1.0.8
-      pathe: 2.0.3
-      srvx: 0.10.0
-      tinyglobby: 0.2.15
-      ufo: 1.6.2
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      xmlbuilder2: 4.0.3
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@tanstack/react-router'
-      - crossws
-      - supports-color
-      - vite-plugin-solid
-      - webpack
+  '@tanstack/start-fn-stubs@1.162.0': {}
 
   '@tanstack/start-plugin-core@1.145.7(@tanstack/react-router@1.145.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -9481,7 +10360,7 @@ snapshots:
       tinyglobby: 0.2.15
       ufo: 1.6.2
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      vitefu: 1.1.3(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       xmlbuilder2: 4.0.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -9489,6 +10368,44 @@ snapshots:
       - '@tanstack/react-router'
       - crossws
       - supports-color
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/start-plugin-core@1.171.19(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/router-generator': 1.167.18
+      '@tanstack/router-plugin': 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)))(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-server-core': 1.169.16
+      exsolve: 1.0.8
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      seroval: 1.5.5
+      source-map: 0.7.6
+      srvx: 0.11.21
+      tinyglobby: 0.2.15
+      ufo: 1.6.2
+      vitefu: 1.1.3(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+      xmlbuilder2: 4.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - '@tanstack/react-router'
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
       - vite-plugin-solid
       - webpack
 
@@ -9504,13 +10421,33 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
+  '@tanstack/start-server-core@1.169.16':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/router-core': 1.171.14
+      '@tanstack/start-client-core': 1.170.13
+      '@tanstack/start-storage-context': 1.167.16
+      fetchdts: 0.1.7
+      h3-v2: h3@2.0.1-rc.20
+      seroval: 1.5.5
+    transitivePeerDependencies:
+      - crossws
+
   '@tanstack/start-storage-context@1.145.7':
     dependencies:
       '@tanstack/router-core': 1.145.7
 
+  '@tanstack/start-storage-context@1.167.16':
+    dependencies:
+      '@tanstack/router-core': 1.171.14
+
   '@tanstack/store@0.8.0': {}
 
+  '@tanstack/store@0.9.3': {}
+
   '@tanstack/virtual-file-routes@1.145.4': {}
+
+  '@tanstack/virtual-file-routes@1.162.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -9544,6 +10481,11 @@ snapshots:
       path-browserify: 1.0.1
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9749,8 +10691,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
 
@@ -9833,18 +10774,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
@@ -9856,6 +10785,11 @@ snapshots:
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -9889,6 +10823,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@3.1.4(vite@6.4.1(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -9980,11 +10922,13 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
   acorn@8.15.0: {}
+
+  acorn@8.17.0: {}
 
   agent-base@7.1.4: {}
 
@@ -10035,6 +10979,8 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  aria-query@5.3.1: {}
 
   aria-query@5.3.2: {}
 
@@ -10162,6 +11108,15 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-dead-code-elimination@1.0.12:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10377,6 +11332,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   ci-info@3.9.0: {}
 
   ci-info@4.3.1: {}
@@ -10460,6 +11419,8 @@ snapshots:
   cookie-es@1.2.2: {}
 
   cookie-es@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie-signature@1.0.7: {}
 
@@ -10793,6 +11754,8 @@ snapshots:
 
   devalue@5.6.1: {}
 
+  devalue@5.8.1: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -10875,6 +11838,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   enquirer@2.4.1:
     dependencies:
@@ -11059,8 +12027,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -11070,6 +12038,10 @@ snapshots:
       estraverse: 5.3.0
 
   esrap@2.2.1:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  esrap@2.2.13:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -11162,6 +12134,12 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fetchdts@0.1.7: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -11345,6 +12323,11 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.2
       uncrypto: 0.1.3
+
+  h3@2.0.1-rc.20:
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.21
 
   h3@2.0.1-rc.7:
     dependencies:
@@ -11705,6 +12688,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
@@ -11810,34 +12795,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -11855,6 +12873,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -12381,6 +13415,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.15: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -12586,6 +13622,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
 
   pkg-types@2.3.0:
@@ -12609,6 +13647,12 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -12617,10 +13661,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.4.1(prettier@3.7.4)(svelte@5.46.3):
+  prettier-plugin-svelte@3.4.1(prettier@3.7.4)(svelte@5.56.4):
     dependencies:
       prettier: 3.7.4
-      svelte: 5.46.3
+      svelte: 5.56.4
 
   prettier@2.8.8: {}
 
@@ -12838,6 +13882,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  readdirp@5.0.0: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -13035,6 +14081,27 @@ snapshots:
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.1
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.1
 
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
+
   rollup@4.54.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -13095,6 +14162,8 @@ snapshots:
       fsevents: 2.3.3
 
   rou3@0.7.12: {}
+
+  rou3@0.8.1: {}
 
   roughjs@4.6.6:
     dependencies:
@@ -13179,9 +14248,15 @@ snapshots:
     dependencies:
       seroval: 1.4.2
 
+  seroval-plugins@1.5.5(seroval@1.5.5):
+    dependencies:
+      seroval: 1.5.5
+
   seroval@1.3.2: {}
 
   seroval@1.4.2: {}
+
+  seroval@1.5.5: {}
 
   serve-static@1.16.3:
     dependencies:
@@ -13195,6 +14270,8 @@ snapshots:
   server-destroy@1.0.1: {}
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -13343,6 +14420,8 @@ snapshots:
 
   srvx@0.10.1: {}
 
+  srvx@0.11.21: {}
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -13398,14 +14477,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.46.3)(typescript@5.8.3):
+  svelte-check@4.3.5(picomatch@4.0.3)(svelte@5.56.4)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.46.3
+      svelte: 5.56.4
       typescript: 5.8.3
     transitivePeerDependencies:
       - picomatch
@@ -13453,6 +14532,27 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  svelte@5.56.4:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.11(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.15.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      esrap: 2.2.13
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   svgo@4.0.0:
     dependencies:
       commander: 11.1.0
@@ -13467,7 +14567,11 @@ snapshots:
 
   tailwindcss@4.1.18: {}
 
+  tailwindcss@4.3.2: {}
+
   tapable@2.3.0: {}
+
+  tapable@2.3.3: {}
 
   term-size@2.2.1: {}
 
@@ -13497,6 +14601,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@1.1.1: {}
 
@@ -13701,6 +14810,17 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
+  unplugin@3.3.0(esbuild@0.27.2)(rolldown@1.1.5)(rollup@4.55.1)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.2
+      rolldown: 1.1.5
+      rollup: 4.55.1
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+
   unstorage@1.17.3:
     dependencies:
       anymatch: 3.1.3
@@ -13801,13 +14921,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@3.1.4(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13822,19 +14942,26 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
+  vite-node@3.2.4(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      '@babel/core': 7.29.0
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.10)
-      merge-anything: 5.1.7
-      solid-js: 1.9.10
-      solid-refresh: 0.6.3(solid-js@1.9.10)
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vitefu: 1.1.3(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
       - supports-color
-    optional: true
+      - terser
+      - tsx
+      - yaml
 
   vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
@@ -13850,6 +14977,20 @@ snapshots:
       - supports-color
     optional: true
 
+  vite-plugin-solid@2.11.10(solid-js@1.9.10)(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.10)
+      merge-anything: 5.1.7
+      solid-js: 1.9.10
+      solid-refresh: 0.6.3(solid-js@1.9.10)
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.3(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2))
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   vite-plugin-static-copy@2.3.2(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       chokidar: 3.6.0
@@ -13858,17 +14999,6 @@ snapshots:
       p-map: 7.0.4
       picocolors: 1.1.1
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-    optionalDependencies:
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.2)(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
@@ -13890,6 +15020,22 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.2
 
+  vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.54.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.27
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
@@ -13906,9 +15052,9 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -13917,24 +15063,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@7.3.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.27
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
+      jiti: 2.7.0
+      lightningcss: 1.32.0
       tsx: 4.21.0
       yaml: 2.8.2
 
@@ -13954,27 +15084,36 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
+  vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.3
+      esbuild: 0.27.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vitefu@1.1.1(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
       vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitefu@1.1.1(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
+  vitefu@1.1.1(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-
-  vitefu@1.1.1(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
-    optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-
-  vitefu@1.1.3(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
-    optionalDependencies:
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    optional: true
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
   vitefu@1.1.3(vite@7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    optional: true
+
+  vitefu@1.1.3(vite@8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)):
+    optionalDependencies:
+      vite: 8.1.4(@types/node@22.19.3)(esbuild@0.27.2)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.2)
 
   vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -13998,6 +15137,47 @@ snapshots:
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       vite-node: 3.1.4(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.19.3
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 3.1.4
+      '@vitest/mocker': 3.1.4(vite@6.4.1(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.1.4
+      '@vitest/snapshot': 3.1.4
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.1.4(@types/node@22.19.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -14141,5 +15321,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/src/bundler-plugins/index.ts
+++ b/src/bundler-plugins/index.ts
@@ -2,5 +2,8 @@ export { paraglideEsbuildPlugin } from "./esbuild.js";
 export { paraglideRolldownPlugin } from "./rolldown.js";
 export { paraglideRollupPlugin } from "./rollup.js";
 export { paraglideRspackPlugin } from "./rspack.js";
-export { paraglideVitePlugin } from "./vite.js";
+export {
+	paraglideVitePlugin,
+	type ParaglideVitePluginOptions,
+} from "./vite.js";
 export { paraglideWebpackPlugin } from "./webpack.js";

--- a/src/bundler-plugins/per-locale-build/constants.ts
+++ b/src/bundler-plugins/per-locale-build/constants.ts
@@ -1,0 +1,3 @@
+export const PER_LOCALE_BUILD_MANIFEST = "paraglide-per-locale.json";
+export const PER_LOCALE_BUILD_MARKER = "__PARAGLIDE_STATIC_LOCALE__";
+export const PER_LOCALE_BUILD_DEFINE = `globalThis.${PER_LOCALE_BUILD_MARKER}`;

--- a/src/bundler-plugins/per-locale-build/framework-helpers.test.ts
+++ b/src/bundler-plugins/per-locale-build/framework-helpers.test.ts
@@ -39,11 +39,11 @@ describe("per-locale build paths", () => {
 });
 
 describe("TanStack Start request locale propagation", () => {
-	test("uses a same-origin Referer for a non-document request", () => {
+	test("uses a same-origin Referer for a TanStack server-function request", () => {
 		const request = new Request("https://example.com/_serverFn/example", {
 			headers: {
 				Referer: "https://example.com/de/produkte?from=server-fn",
-				"Sec-Fetch-Dest": "empty",
+				"x-tsr-serverFn": "true",
 			},
 		});
 		expect(getTanStackStartEffectiveRequestUrl(request).href).toBe(
@@ -51,12 +51,9 @@ describe("TanStack Start request locale propagation", () => {
 		);
 	});
 
-	test("never replaces a document URL with its Referer", () => {
+	test("does not use Referer for an unmarked navigation without Fetch Metadata", () => {
 		const request = new Request("https://example.com/en/products", {
-			headers: {
-				Referer: "https://example.com/de/produkte",
-				"Sec-Fetch-Dest": "document",
-			},
+			headers: { Referer: "https://example.com/de/produkte" },
 		});
 		expect(getTanStackStartEffectiveRequestUrl(request).href).toBe(request.url);
 	});
@@ -66,7 +63,7 @@ describe("TanStack Start request locale propagation", () => {
 		["an invalid Referer", "not a url"],
 	])("ignores %s", (_label, referer) => {
 		const request = new Request("https://example.com/_serverFn/example", {
-			headers: { Referer: referer, "Sec-Fetch-Dest": "empty" },
+			headers: { Referer: referer, "x-tsr-serverFn": "true" },
 		});
 		expect(getTanStackStartEffectiveRequestUrl(request).href).toBe(request.url);
 	});

--- a/src/bundler-plugins/per-locale-build/framework-helpers.test.ts
+++ b/src/bundler-plugins/per-locale-build/framework-helpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import {
+	createTanStackStartFramework,
+	getTanStackStartEffectiveRequestUrl,
+	getPerLocaleBuildPrefix,
+	prefixPerLocaleAssetUrl,
+} from "./frameworks/tanstack-start.js";
+import { getPerLocaleBuildLocaleId } from "./locale-id.js";
+
+describe("per-locale build paths", () => {
+	test("locale ids are readable, filesystem safe, and collision free", () => {
+		expect(getPerLocaleBuildLocaleId("de")).toBe("de-6465");
+		expect(getPerLocaleBuildLocaleId("pt-BR")).toBe("pt-BR-70742d4252");
+		expect(getPerLocaleBuildLocaleId("中文")).toBe("__-e4b8ade69687");
+		expect(getPerLocaleBuildLocaleId("en/us")).not.toBe(
+			getPerLocaleBuildLocaleId("en?us")
+		);
+		expect(getPerLocaleBuildPrefix("de")).toBe("/__paraglide/de-6465");
+	});
+
+	test("prefixes same-origin asset URLs and rejects CDN URLs", () => {
+		const prefix = getPerLocaleBuildPrefix("de");
+		expect(prefixPerLocaleAssetUrl("/assets/app.js?v=1", prefix)).toBe(
+			"/__paraglide/de-6465/assets/app.js?v=1"
+		);
+		expect(prefixPerLocaleAssetUrl("assets/app.js", prefix)).toBe(
+			"/__paraglide/de-6465/assets/app.js"
+		);
+		expect(() =>
+			prefixPerLocaleAssetUrl("https://cdn.example/assets/app.js", prefix)
+		).toThrow("root-relative and relative");
+		expect(() =>
+			prefixPerLocaleAssetUrl("//cdn.example/assets/app.js", prefix)
+		).toThrow("root-relative and relative");
+		expect(prefixPerLocaleAssetUrl("/assets/app.js", "")).toBe(
+			"/assets/app.js"
+		);
+	});
+});
+
+describe("TanStack Start request locale propagation", () => {
+	test("uses a same-origin Referer for a non-document request", () => {
+		const request = new Request("https://example.com/_serverFn/example", {
+			headers: {
+				Referer: "https://example.com/de/produkte?from=server-fn",
+				"Sec-Fetch-Dest": "empty",
+			},
+		});
+		expect(getTanStackStartEffectiveRequestUrl(request).href).toBe(
+			"https://example.com/de/produkte?from=server-fn"
+		);
+	});
+
+	test("never replaces a document URL with its Referer", () => {
+		const request = new Request("https://example.com/en/products", {
+			headers: {
+				Referer: "https://example.com/de/produkte",
+				"Sec-Fetch-Dest": "document",
+			},
+		});
+		expect(getTanStackStartEffectiveRequestUrl(request).href).toBe(request.url);
+	});
+
+	test.each([
+		["a cross-origin Referer", "https://attacker.example/de"],
+		["an invalid Referer", "not a url"],
+	])("ignores %s", (_label, referer) => {
+		const request = new Request("https://example.com/_serverFn/example", {
+			headers: { Referer: referer, "Sec-Fetch-Dest": "empty" },
+		});
+		expect(getTanStackStartEffectiveRequestUrl(request).href).toBe(request.url);
+	});
+});
+
+test("generates one self-contained TanStack Start server adapter", () => {
+	const files = createTanStackStartFramework().generatedFiles ?? {};
+	const server = files["tanstack-start.server.js"];
+	expect(Object.keys(files)).toEqual(["tanstack-start.server.js"]);
+	expect(server).not.toContain("@inlang/paraglide-js");
+	expect(server).toContain("cache: false");
+	expect(server).toContain(getPerLocaleBuildLocaleId.toString());
+	expect(server).toContain('from "@tanstack/react-start/server"');
+	expect(server).toContain(
+		"effectiveRequestUrl: getEffectiveRequestUrl(request)"
+	);
+});

--- a/src/bundler-plugins/per-locale-build/frameworks/index.ts
+++ b/src/bundler-plugins/per-locale-build/frameworks/index.ts
@@ -1,0 +1,36 @@
+import type { ResolvedConfig, UserConfig } from "vite";
+import type { PerLocaleBuildFramework } from "../types.js";
+import {
+	createSvelteKitFramework,
+	hasSvelteKitConfig,
+	hasSvelteKitSetupPlugin,
+} from "./sveltekit.js";
+import {
+	configureTanStackStartBuild,
+	createTanStackStartFramework,
+	isTanStackStartConfig,
+} from "./tanstack-start.js";
+
+export function configurePerLocaleBuild(config: UserConfig) {
+	if (hasSvelteKitConfig(config)) {
+		return {};
+	}
+	return configureTanStackStartBuild(config);
+}
+
+export function detectPerLocaleBuildFramework(
+	config: Pick<ResolvedConfig, "plugins" | "define">
+): PerLocaleBuildFramework {
+	const hasTanStackStart = isTanStackStartConfig(config);
+	const hasSvelteKit = hasSvelteKitSetupPlugin(config);
+	if (hasTanStackStart && hasSvelteKit) {
+		throw new Error(
+			"experimentalPerLocaleBuild found both TanStack Start and SvelteKit Vite plugins. Use it with exactly one supported framework."
+		);
+	}
+	if (hasTanStackStart) return createTanStackStartFramework();
+	if (hasSvelteKit) return createSvelteKitFramework(config);
+	throw new Error(
+		"experimentalPerLocaleBuild supports TanStack Start and SvelteKit. Add one of their Vite plugins, or disable this flag."
+	);
+}

--- a/src/bundler-plugins/per-locale-build/frameworks/sveltekit.ts
+++ b/src/bundler-plugins/per-locale-build/frameworks/sveltekit.ts
@@ -1,0 +1,224 @@
+import type { Plugin, ResolvedConfig } from "vite";
+import nodeFs from "node:fs";
+import path from "node:path";
+import type {
+	PerLocaleBuildFramework,
+	PerLocaleBuildLayout,
+	PerLocaleBuildServerIntegration,
+} from "../types.js";
+import { getPerLocaleBuildLocaleId } from "../locale-id.js";
+
+export const SVELTEKIT_VIRTUAL_MODULE_ID =
+	"virtual:paraglide-per-locale-build/sveltekit";
+export const RESOLVED_SVELTEKIT_VIRTUAL_MODULE_ID =
+	"\0virtual:paraglide-per-locale-build/sveltekit";
+
+type SvelteKitSetupPlugin = Plugin & {
+	api?: {
+		options?: {
+			kit?: {
+				appDir?: string;
+				files?: { serviceWorker?: string };
+				output?: { bundleStrategy?: string };
+				paths?: { assets?: string; base?: string };
+				router?: { resolution?: string };
+			};
+		};
+	};
+};
+
+export function hasSvelteKitSetupPlugin(
+	config: Pick<ResolvedConfig, "plugins">
+): boolean {
+	return config.plugins.some(
+		(plugin) => plugin.name === "vite-plugin-sveltekit-setup"
+	);
+}
+
+/** Early config-hook detection before SvelteKit's validated plugin API is available. */
+export function hasSvelteKitConfig(config: {
+	define?: Record<string, unknown>;
+}): boolean {
+	return Object.hasOwn(config.define ?? {}, "__SVELTEKIT_APP_DIR__");
+}
+
+export function createSvelteKitFramework(
+	config: Pick<ResolvedConfig, "plugins">
+): PerLocaleBuildFramework {
+	const setupPlugin = config.plugins.find(
+		(plugin) => plugin.name === "vite-plugin-sveltekit-setup"
+	) as SvelteKitSetupPlugin | undefined;
+	const kit = setupPlugin?.api?.options?.kit;
+	if (!kit) {
+		throw new Error(
+			"experimentalPerLocaleBuild is currently tested with SvelteKit 2.69.x and requires its validated Vite plugin configuration."
+		);
+	}
+	if (
+		kit.appDir !== "_app" ||
+		kit.paths?.base ||
+		kit.paths?.assets ||
+		kit.output?.bundleStrategy !== "split" ||
+		kit.router?.resolution !== "client" ||
+		(kit.files?.serviceWorker && svelteKitEntryExists(kit.files.serviceWorker))
+	) {
+		throw new Error(
+			'experimentalPerLocaleBuild currently supports only the tested SvelteKit 2.69.x defaults: kit.appDir="_app", empty kit.paths.base/assets, kit.output.bundleStrategy="split", kit.router.resolution="client", and no service worker.'
+		);
+	}
+	return {
+		layout: createSvelteKitLayout(),
+		createServerIntegration({ root, generatedDirectory }) {
+			return createSvelteKitServerIntegration({
+				root,
+				generatedDirectory,
+			});
+		},
+	};
+}
+
+export function createSvelteKitLayout(): PerLocaleBuildLayout {
+	const immutablePrefix = "_app/immutable/";
+	return {
+		validateOutput(fileName, type) {
+			if (type === "chunk" && !fileName.startsWith(immutablePrefix)) {
+				throw new Error(
+					`experimentalPerLocaleBuild expected every SvelteKit client chunk below ${JSON.stringify(immutablePrefix)}, but found ${JSON.stringify(fileName)}. Only the tested SvelteKit 2.69.x default client output is supported.`
+				);
+			}
+		},
+		getLocalePrefix(locale, baseLocale) {
+			return locale === baseLocale
+				? ""
+				: `/_app/immutable/__paraglide/${getPerLocaleBuildLocaleId(locale)}`;
+		},
+		getLocalizedFileName(fileName, locale, baseLocale) {
+			if (locale === baseLocale || !fileName.startsWith(immutablePrefix)) {
+				return fileName;
+			}
+			return `${immutablePrefix}__paraglide/${getPerLocaleBuildLocaleId(locale)}/${fileName.slice(immutablePrefix.length)}`;
+		},
+	};
+}
+
+export function createSvelteKitServerIntegration(args: {
+	root: string;
+	generatedDirectory: string;
+}): PerLocaleBuildServerIntegration {
+	let renderPatched = false;
+
+	return {
+		resolveId(id: string): string | undefined {
+			return id === SVELTEKIT_VIRTUAL_MODULE_ID
+				? RESOLVED_SVELTEKIT_VIRTUAL_MODULE_ID
+				: undefined;
+		},
+		load(id: string): string | undefined {
+			if (id !== RESOLVED_SVELTEKIT_VIRTUAL_MODULE_ID) return;
+			return createSvelteKitVirtualModuleSource(args);
+		},
+		transform(
+			code: string,
+			id: string
+		): { code: string; map: null } | undefined {
+			const normalizedId = normalizeModuleId(id.split("?", 1)[0] ?? id);
+			if (
+				normalizedId.endsWith(
+					"/@sveltejs/kit/src/runtime/server/page/render.js"
+				)
+			) {
+				renderPatched = true;
+				return { code: patchSvelteKitRenderModule(code), map: null };
+			}
+			return undefined;
+		},
+		assertPatched(): void {
+			if (!renderPatched) {
+				throw new Error(
+					"experimentalPerLocaleBuild could not integrate with SvelteKit because its tested 2.69.x server rendering internals were not found."
+				);
+			}
+		},
+	};
+}
+
+export function createSvelteKitVirtualModuleSource(args: {
+	root: string;
+	generatedDirectory: string;
+}): string {
+	const generatedDirectory = path.resolve(args.root, args.generatedDirectory);
+	const runtimeModule = normalizeModuleId(
+		path.join(generatedDirectory, "runtime.js")
+	);
+	return [
+		`import { baseLocale, getLocale, locales } from ${JSON.stringify(runtimeModule)};`,
+		`const getLocaleId = ${getPerLocaleBuildLocaleId.toString()};`,
+		"export function localizeSvelteKitAssetPath(path) {",
+		"\tconst locale = getLocale();",
+		"\tif (locale === baseLocale) return path;",
+		'\tconst marker = "_app/immutable/";',
+		"\tif (!path.includes(marker)) return path;",
+		'\tconst localizedMarker = marker + "__paraglide/" + getLocaleId(locale) + "/";',
+		"\treturn path.includes(localizedMarker)",
+		"\t\t? path",
+		"\t\t: path.replace(marker, localizedMarker);",
+		"}",
+		"export function assertSvelteKitPerLocaleFallbackSupported(fallback) {",
+		"\tif (fallback && locales.length > 1) {",
+		'\t\tthrow new Error("experimentalPerLocaleBuild does not support SvelteKit SPA fallback pages because one fallback cannot select a request-locale client graph. Use SSR or prerender every locale-specific page.");',
+		"\t}",
+		"}",
+		"",
+	].join("\n");
+}
+
+export function patchSvelteKitRenderModule(code: string): string {
+	const marker = "const prefixed = (path) => {";
+	const renderResponseMarker = "}) {\n\tif (state.prerendering) {";
+	assertSingleSvelteKitMarker(code, marker, "server/page/render.js");
+	assertSingleSvelteKitMarker(
+		code,
+		renderResponseMarker,
+		"server/page/render.js"
+	);
+	return `${svelteKitVirtualImport}\n${code
+		.replace(
+			renderResponseMarker,
+			`}) {\n\t__paraglideAssertSvelteKitPerLocaleFallbackSupported(state.prerendering?.fallback);\n\n\tif (state.prerendering) {`
+		)
+		.replace(
+			marker,
+			`${marker}\n\t\tpath = __paraglideLocalizeSvelteKitAssetPath(path);`
+		)}`;
+}
+
+const svelteKitVirtualImport = `import { assertSvelteKitPerLocaleFallbackSupported as __paraglideAssertSvelteKitPerLocaleFallbackSupported, localizeSvelteKitAssetPath as __paraglideLocalizeSvelteKitAssetPath } from ${JSON.stringify(SVELTEKIT_VIRTUAL_MODULE_ID)};`;
+
+function assertSingleSvelteKitMarker(
+	code: string,
+	marker: string,
+	moduleName: string
+): void {
+	if (code.split(marker).length !== 2) {
+		throw new Error(
+			`experimentalPerLocaleBuild cannot patch this SvelteKit ${moduleName}; its internal asset rendering differs from the tested SvelteKit 2.69.x implementation.`
+		);
+	}
+}
+
+function normalizeModuleId(id: string): string {
+	return id.replaceAll("\\", "/");
+}
+
+function svelteKitEntryExists(entry: string): boolean {
+	return [
+		entry,
+		`${entry}.js`,
+		`${entry}.ts`,
+		path.join(entry, "index.js"),
+		path.join(entry, "index.ts"),
+	].some(
+		(candidate) =>
+			nodeFs.existsSync(candidate) && nodeFs.statSync(candidate).isFile()
+	);
+}

--- a/src/bundler-plugins/per-locale-build/frameworks/tanstack-start.ts
+++ b/src/bundler-plugins/per-locale-build/frameworks/tanstack-start.ts
@@ -20,7 +20,7 @@ export function prefixPerLocaleAssetUrl(url: string, prefix: string): string {
 
 export function getTanStackStartEffectiveRequestUrl(request: Request): URL {
 	const requestUrl = new URL(request.url);
-	if (request.headers.get("Sec-Fetch-Dest") === "document") return requestUrl;
+	if (request.headers.get("x-tsr-serverFn") !== "true") return requestUrl;
 	const referer = request.headers.get("Referer");
 	if (referer === null) return requestUrl;
 	try {

--- a/src/bundler-plugins/per-locale-build/frameworks/tanstack-start.ts
+++ b/src/bundler-plugins/per-locale-build/frameworks/tanstack-start.ts
@@ -1,0 +1,117 @@
+import type { ResolvedConfig } from "vite";
+import type { PerLocaleBuildFramework } from "../types.js";
+import { getPerLocaleBuildLocaleId } from "../locale-id.js";
+
+export const PER_LOCALE_BUILD_ASSET_PREFIX = "/__paraglide";
+
+export function getPerLocaleBuildPrefix(locale: string): string {
+	return `${PER_LOCALE_BUILD_ASSET_PREFIX}/${getPerLocaleBuildLocaleId(locale)}`;
+}
+
+export function prefixPerLocaleAssetUrl(url: string, prefix: string): string {
+	if (url.startsWith("//") || /^[A-Za-z][A-Za-z\d+.-]*:/.test(url)) {
+		throw new Error(
+			"experimentalPerLocaleBuild supports only root-relative and relative TanStack Start asset URLs."
+		);
+	}
+	if (prefix === "") return url;
+	return `${prefix}/${url.replace(/^\/+/, "")}`;
+}
+
+export function getTanStackStartEffectiveRequestUrl(request: Request): URL {
+	const requestUrl = new URL(request.url);
+	if (request.headers.get("Sec-Fetch-Dest") === "document") return requestUrl;
+	const referer = request.headers.get("Referer");
+	if (referer === null) return requestUrl;
+	try {
+		const refererUrl = new URL(referer);
+		return refererUrl.origin === requestUrl.origin ? refererUrl : requestUrl;
+	} catch {
+		return requestUrl;
+	}
+}
+
+export function isTanStackStartConfig(
+	config: Pick<ResolvedConfig, "plugins">
+): boolean {
+	return config.plugins.some(
+		(plugin) => plugin.name === "tanstack-start-core:config"
+	);
+}
+
+export function createTanStackStartFramework(): PerLocaleBuildFramework {
+	return {
+		generatedFiles: {
+			"tanstack-start.server.js": tanstackStartServerRuntime,
+		},
+		layout: {
+			getLocalePrefix(locale, baseLocale) {
+				return locale === baseLocale ? "" : getPerLocaleBuildPrefix(locale);
+			},
+			getLocalizedFileName(fileName, locale, baseLocale) {
+				if (locale === baseLocale) return fileName;
+				return `${getPerLocaleBuildPrefix(locale).replace(/^\//, "")}/${fileName}`;
+			},
+		},
+	};
+}
+
+export function configureTanStackStartBuild(config: {
+	experimental?: { renderBuiltUrl?: unknown };
+}) {
+	if (config.experimental?.renderBuiltUrl) {
+		throw new Error(
+			"experimentalPerLocaleBuild cannot be combined with experimental.renderBuiltUrl because locale asset trees require relative client URLs and canonical SSR URLs."
+		);
+	}
+	return {
+		base: "",
+		experimental: {
+			renderBuiltUrl(filename: string, context: { ssr?: boolean }) {
+				if (context.ssr) return `/${filename.replace(/^\/+/, "")}`;
+				return { relative: true as const };
+			},
+		},
+	};
+}
+
+const tanstackStartServerRuntime = String.raw`
+// @ts-nocheck -- generated only for experimentalPerLocaleBuild on TanStack Start
+import {
+	createStartHandler,
+	defaultStreamHandler,
+} from "@tanstack/react-start/server";
+import { baseLocale, getLocale } from "./runtime.js";
+import { paraglideMiddleware } from "./server.js";
+
+const getPerLocaleBuildLocaleId = ${getPerLocaleBuildLocaleId.toString()};
+const PER_LOCALE_BUILD_ASSET_PREFIX = "/__paraglide";
+const getLocalePrefix = ${getPerLocaleBuildPrefix.toString()};
+const prefixAssetUrl = ${prefixPerLocaleAssetUrl.toString()};
+const getEffectiveRequestUrl = ${getTanStackStartEffectiveRequestUrl.toString()};
+
+const fetch = createStartHandler({
+	handler: defaultStreamHandler,
+	transformAssets: {
+		cache: false,
+		createTransform() {
+			const locale = getLocale();
+			const prefix =
+				import.meta.env?.PROD === true && locale !== baseLocale
+					? getLocalePrefix(locale)
+					: "";
+			return ({ url }) => prefixAssetUrl(url, prefix);
+		},
+	},
+});
+
+export default {
+	fetch(request, ...args) {
+		return paraglideMiddleware(
+			request,
+			() => fetch(request, ...args),
+			{ effectiveRequestUrl: getEffectiveRequestUrl(request) },
+		);
+	},
+};
+`.trimStart();

--- a/src/bundler-plugins/per-locale-build/index.ts
+++ b/src/bundler-plugins/per-locale-build/index.ts
@@ -1,0 +1,110 @@
+import nodeFs from "node:fs";
+import { loadProjectFromDirectory } from "@inlang/sdk";
+import type { Plugin } from "vite";
+import type { CompilerOptions } from "../../compiler/compiler-options.js";
+import { perLocaleBuildStaticLocaleExpression } from "../../compiler/per-locale-build.js";
+import type { PerLocaleBuildSettings } from "./types.js";
+import { createPerLocaleBuildVitePlugin } from "./vite-plugin.js";
+
+export function createPerLocaleBuildPlugins(args: {
+	compilerOptions: CompilerOptions;
+	createCompilerPlugin: (options: CompilerOptions) => Plugin;
+}): Plugin[] {
+	const { compilerOptions } = args;
+	validateCompilerOptions(compilerOptions);
+
+	const perLocaleCompilerOptions: CompilerOptions = {
+		...compilerOptions,
+		outputStructure: compilerOptions.outputStructure ?? "message-modules",
+		experimentalStaticLocale: perLocaleBuildStaticLocaleExpression,
+		additionalFiles: {
+			...compilerOptions.additionalFiles,
+		},
+	};
+
+	return [
+		args.createCompilerPlugin(perLocaleCompilerOptions),
+		createPerLocaleBuildVitePlugin({
+			// Reload settings for every client build so Vite build --watch picks up
+			// locale additions/removals instead of reusing the first build's project.
+			settings: () => loadSettings(perLocaleCompilerOptions),
+			generatedDirectory: perLocaleCompilerOptions.outdir,
+			onFrameworkDetected(frameworkFiles) {
+				assertGeneratedFilesAvailable(
+					frameworkFiles,
+					compilerOptions.additionalFiles
+				);
+				perLocaleCompilerOptions.additionalFiles = {
+					...perLocaleCompilerOptions.additionalFiles,
+					...frameworkFiles,
+				};
+			},
+		}),
+	];
+}
+
+function validateCompilerOptions(options: CompilerOptions): void {
+	if (
+		options.strategy !== undefined &&
+		options.strategy[0] !== "url" &&
+		options.strategy[0] !== "cookie"
+	) {
+		throw new Error(
+			'experimentalPerLocaleBuild requires the first locale strategy to be "url" or "cookie".'
+		);
+	}
+	if (options.routeStrategies !== undefined) {
+		throw new Error(
+			"experimentalPerLocaleBuild does not support routeStrategies."
+		);
+	}
+	if (options.experimentalStaticLocale !== undefined) {
+		throw new Error(
+			"experimentalPerLocaleBuild cannot be combined with experimentalStaticLocale because it controls the compiler's static locale expression."
+		);
+	}
+	if (options.experimentalMiddlewareLocaleSplitting) {
+		throw new Error(
+			"experimentalPerLocaleBuild cannot be combined with experimentalMiddlewareLocaleSplitting."
+		);
+	}
+	if (
+		options.outputStructure !== undefined &&
+		options.outputStructure !== "message-modules"
+	) {
+		throw new Error(
+			'experimentalPerLocaleBuild currently requires outputStructure: "message-modules".'
+		);
+	}
+}
+
+function assertGeneratedFilesAvailable(
+	generatedFiles: Record<string, string>,
+	additionalFiles: CompilerOptions["additionalFiles"]
+): void {
+	for (const fileName of Object.keys(generatedFiles)) {
+		if (Object.hasOwn(additionalFiles ?? {}, fileName)) {
+			throw new Error(
+				`experimentalPerLocaleBuild needs to generate ${JSON.stringify(fileName)}, but additionalFiles already defines that path.`
+			);
+		}
+	}
+}
+
+async function loadSettings(
+	options: Pick<CompilerOptions, "project" | "fs">
+): Promise<PerLocaleBuildSettings> {
+	const project = await loadProjectFromDirectory({
+		path: options.project,
+		fs: options.fs ?? nodeFs,
+	});
+	try {
+		const settings = await project.settings.get();
+		return {
+			baseLocale: settings.baseLocale,
+			locales: [...settings.locales],
+		};
+	} finally {
+		await project.close();
+	}
+}

--- a/src/bundler-plugins/per-locale-build/locale-id.ts
+++ b/src/bundler-plugins/per-locale-build/locale-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns a readable, filesystem-safe, collision-free identifier for a locale.
+ *
+ * The readable part is only for diagnostics. The complete UTF-8 hex suffix is
+ * what guarantees that two different locale strings never share an output
+ * directory, including locales which differ only by punctuation or Unicode.
+ */
+export function getPerLocaleBuildLocaleId(locale: string): string {
+	const readable = locale.replace(/[^A-Za-z0-9_-]/g, "_") || "locale";
+	const hex = Array.from(new TextEncoder().encode(locale), (byte) =>
+		byte.toString(16).padStart(2, "0")
+	).join("");
+	return `${readable}-${hex}`;
+}

--- a/src/bundler-plugins/per-locale-build/specialize-bundle.ts
+++ b/src/bundler-plugins/per-locale-build/specialize-bundle.ts
@@ -1,0 +1,279 @@
+import type { OutputBundle } from "rolldown";
+import path from "node:path";
+import {
+	PER_LOCALE_BUILD_DEFINE,
+	PER_LOCALE_BUILD_MANIFEST,
+	PER_LOCALE_BUILD_MARKER,
+} from "./constants.js";
+import type {
+	PerLocaleBuildLayout,
+	PerLocaleBuildManifest,
+	PerLocaleBuildSettings,
+	ViteOxcApi,
+} from "./types.js";
+
+export async function specializePerLocaleBundle(args: {
+	bundle: OutputBundle;
+	layout: PerLocaleBuildLayout;
+	settings: PerLocaleBuildSettings;
+	vite: ViteOxcApi;
+}): Promise<{
+	manifest: PerLocaleBuildManifest;
+	assets: Array<{ fileName: string; source: string | Uint8Array }>;
+}> {
+	const settings = validatePerLocaleBuildSettings(args.settings);
+	assertVite8OxcApi(args.vite);
+
+	const originals = Object.entries(args.bundle)
+		.filter(([fileName]) => fileName !== PER_LOCALE_BUILD_MANIFEST)
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([fileName, output]) => ({
+			fileName,
+			output,
+			// Base-locale specialization mutates the canonical OutputChunk. Every
+			// locale must nevertheless start from this immutable source graph.
+			code: output.type === "chunk" ? output.code : undefined,
+		}));
+	const originalFileNames = originals.map(({ fileName }) => fileName);
+	const originalFileNameSet = new Set(originalFileNames);
+	for (const { fileName, output } of originals) {
+		args.layout.validateOutput?.(fileName, output.type);
+	}
+	for (const { fileName, output } of originals) {
+		if (output.type !== "asset" || !fileName.endsWith(".css")) continue;
+		output.source = rewriteCssPublicAssetReferences({
+			source: output.source,
+			fileName,
+			originalFileNames: originalFileNameSet,
+		});
+	}
+
+	const manifest: PerLocaleBuildManifest = {
+		version: 1,
+		baseLocale: settings.baseLocale,
+		locales: {},
+	};
+	for (const locale of settings.locales) {
+		manifest.locales[locale] = {
+			prefix: args.layout.getLocalePrefix(locale, settings.baseLocale),
+			assets: Object.fromEntries(
+				originalFileNames.map((fileName) => [
+					`/${fileName}`,
+					`/${args.layout.getLocalizedFileName(fileName, locale, settings.baseLocale)}`,
+				])
+			),
+		};
+	}
+	const localizedAssets: Array<{
+		fileName: string;
+		source: string | Uint8Array;
+	}> = [];
+	const emittedFileNames = new Set(Object.keys(args.bundle));
+
+	for (const locale of settings.locales) {
+		const specializedChunks = new Map<string, string>();
+		await Promise.all(
+			originals.map(async ({ fileName, output, code }) => {
+				if (output.type !== "chunk") return;
+				specializedChunks.set(
+					fileName,
+					await specializeChunk({
+						code: code!,
+						fileName,
+						locale,
+						vite: args.vite,
+					})
+				);
+			})
+		);
+
+		for (const { fileName, output } of originals) {
+			const specializedCode =
+				output.type === "chunk" ? specializedChunks.get(fileName) : undefined;
+			if (output.type === "chunk" && specializedCode === undefined) {
+				throw new Error(`Failed to specialize Vite chunk ${fileName}.`);
+			}
+
+			if (locale === settings.baseLocale) {
+				if (output.type === "chunk") {
+					output.code = specializedCode!;
+					output.map = null;
+				}
+				continue;
+			}
+
+			const localizedFileName = args.layout.getLocalizedFileName(
+				fileName,
+				locale,
+				settings.baseLocale
+			);
+			if (localizedFileName === fileName) continue;
+			if (emittedFileNames.has(localizedFileName)) {
+				throw new Error(
+					`experimentalPerLocaleBuild cannot emit ${localizedFileName} because another Vite plugin already emitted that file.`
+				);
+			}
+			emittedFileNames.add(localizedFileName);
+			localizedAssets.push({
+				fileName: localizedFileName,
+				source: output.type === "chunk" ? specializedCode! : output.source,
+			});
+		}
+	}
+
+	return { manifest, assets: localizedAssets };
+}
+
+function rewriteCssPublicAssetReferences(args: {
+	source: string | Uint8Array;
+	fileName: string;
+	originalFileNames: Set<string>;
+}): string | Uint8Array {
+	let css: string;
+	if (typeof args.source === "string") {
+		css = args.source;
+	} else {
+		css = new TextDecoder().decode(args.source);
+	}
+	const rewrite = (reference: string): string => {
+		if (!isRelativeCssReference(reference)) return reference;
+		const suffixIndex = reference.search(/[?#]/);
+		const pathname =
+			suffixIndex === -1 ? reference : reference.slice(0, suffixIndex);
+		const suffix = suffixIndex === -1 ? "" : reference.slice(suffixIndex);
+		const canonicalPath = path.posix.normalize(
+			path.posix.join("/", path.posix.dirname(args.fileName), pathname)
+		);
+		if (args.originalFileNames.has(canonicalPath.replace(/^\//, ""))) {
+			return reference;
+		}
+		return `${canonicalPath}${suffix}`;
+	};
+	css = css.replace(
+		/url\(\s*(?:(["'])(.*?)\1|([^"')]+))\s*\)/g,
+		(
+			full: string,
+			quote: string | undefined,
+			quoted: string,
+			unquoted: string
+		) => {
+			const reference = (quote ? quoted : unquoted).trim();
+			const rewritten = rewrite(reference);
+			return rewritten === reference
+				? full
+				: `url(${quote ?? ""}${rewritten}${quote ?? ""})`;
+		}
+	);
+	css = css.replace(
+		/@import\s+(["'])(.*?)\1/g,
+		(full: string, quote: string, reference: string) => {
+			const rewritten = rewrite(reference);
+			return rewritten === reference
+				? full
+				: `@import ${quote}${rewritten}${quote}`;
+		}
+	);
+	return typeof args.source === "string" ? css : new TextEncoder().encode(css);
+}
+
+function isRelativeCssReference(reference: string): boolean {
+	return (
+		reference !== "" &&
+		!reference.startsWith("/") &&
+		!reference.startsWith("#") &&
+		!reference.startsWith("?") &&
+		!reference.startsWith("//") &&
+		!reference.startsWith("var(") &&
+		!reference.startsWith("data:") &&
+		!/^[A-Za-z][A-Za-z\d+.-]*:/.test(reference)
+	);
+}
+
+async function specializeChunk(args: {
+	code: string;
+	fileName: string;
+	locale: string;
+	vite: ViteOxcApi;
+}): Promise<string> {
+	const transformed = await args.vite.transformWithOxc(
+		args.code,
+		args.fileName,
+		{
+			lang: "js",
+			sourceType: "module",
+			define: {
+				[PER_LOCALE_BUILD_DEFINE]: JSON.stringify(args.locale),
+			},
+			sourcemap: false,
+		}
+	);
+	const minified = await args.vite.minify(args.fileName, transformed.code, {
+		module: true,
+		compress: true,
+		mangle: true,
+	});
+	if (minified.errors.length > 0) {
+		throw new Error(
+			`Oxc failed to minify ${args.fileName} for locale ${JSON.stringify(args.locale)}: ${minified.errors.map((error) => error.message).join("\n")}`
+		);
+	}
+	if (minified.code.includes(PER_LOCALE_BUILD_MARKER)) {
+		throw new Error(
+			`Oxc left ${PER_LOCALE_BUILD_MARKER} in ${args.fileName} for locale ${JSON.stringify(args.locale)}.`
+		);
+	}
+	return minified.code;
+}
+
+export async function loadViteOxcApi(): Promise<ViteOxcApi> {
+	try {
+		return await import("vite");
+	} catch (error) {
+		throw new Error(
+			"experimentalPerLocaleBuild requires Vite 8 to be installed in the application.",
+			{ cause: error }
+		);
+	}
+}
+
+export function assertVite8OxcApi(
+	vite: Partial<ViteOxcApi>
+): asserts vite is ViteOxcApi {
+	const major = Number.parseInt(vite.version?.split(".")[0] ?? "", 10);
+	if (
+		!Number.isFinite(major) ||
+		major !== 8 ||
+		typeof vite.transformWithOxc !== "function" ||
+		typeof vite.minify !== "function"
+	) {
+		throw new Error(
+			`experimentalPerLocaleBuild requires Vite 8 with the Oxc transform and minify APIs (received ${vite.version ?? "an unknown version"}).`
+		);
+	}
+}
+
+export function validatePerLocaleBuildSettings(
+	settings: PerLocaleBuildSettings
+): PerLocaleBuildSettings {
+	if (!settings.baseLocale) {
+		throw new Error(
+			"experimentalPerLocaleBuild requires the inlang project to define a baseLocale."
+		);
+	}
+	if (!Array.isArray(settings.locales) || settings.locales.length === 0) {
+		throw new Error(
+			"experimentalPerLocaleBuild requires the inlang project to define at least one locale."
+		);
+	}
+	if (!settings.locales.includes(settings.baseLocale)) {
+		throw new Error(
+			`experimentalPerLocaleBuild baseLocale ${JSON.stringify(settings.baseLocale)} is not present in the project's locales.`
+		);
+	}
+	if (new Set(settings.locales).size !== settings.locales.length) {
+		throw new Error(
+			"experimentalPerLocaleBuild requires every project locale to be unique."
+		);
+	}
+	return settings;
+}

--- a/src/bundler-plugins/per-locale-build/types.ts
+++ b/src/bundler-plugins/per-locale-build/types.ts
@@ -1,0 +1,56 @@
+export type PerLocaleBuildSettings = {
+	baseLocale: string;
+	locales: string[];
+};
+
+export type PerLocaleBuildManifest = {
+	version: 1;
+	baseLocale: string;
+	locales: Record<
+		string,
+		{
+			/** Public URL prefix. Empty for the canonical/base-locale build. */
+			prefix: string;
+			/** Canonical public URL to locale-specific public URL. */
+			assets: Record<string, string>;
+		}
+	>;
+};
+
+export type ViteOxcApi = Pick<
+	typeof import("vite"),
+	"version" | "transformWithOxc" | "minify"
+>;
+
+/** Framework-neutral description of a client bundle's output namespace. */
+export type PerLocaleBuildLayout = {
+	/** Reject unsupported framework output before specialization begins. */
+	validateOutput?: (fileName: string, type: "asset" | "chunk") => void;
+	getLocalePrefix: (locale: string, baseLocale: string) => string;
+	/** Returning the original filename keeps that output locale-neutral. */
+	getLocalizedFileName: (
+		fileName: string,
+		locale: string,
+		baseLocale: string
+	) => string;
+};
+
+export type PerLocaleBuildServerIntegration = {
+	resolveId: (id: string) => string | undefined;
+	load: (id: string) => string | undefined;
+	transform: (
+		code: string,
+		id: string
+	) => { code: string; map: null } | undefined;
+	assertPatched: () => void;
+};
+
+/** Framework policy consumed by the Vite lifecycle orchestrator. */
+export type PerLocaleBuildFramework = {
+	layout: PerLocaleBuildLayout;
+	generatedFiles?: Record<string, string>;
+	createServerIntegration?: (args: {
+		root: string;
+		generatedDirectory: string;
+	}) => PerLocaleBuildServerIntegration;
+};

--- a/src/bundler-plugins/per-locale-build/vite-plugin.test.ts
+++ b/src/bundler-plugins/per-locale-build/vite-plugin.test.ts
@@ -1,0 +1,601 @@
+import { expect, test } from "vitest";
+import type { OutputBundle } from "rolldown";
+import { minify, transformWithOxc, version } from "vite";
+import {
+	PER_LOCALE_BUILD_DEFINE,
+	PER_LOCALE_BUILD_MANIFEST,
+} from "./constants.js";
+import { detectPerLocaleBuildFramework } from "./frameworks/index.js";
+import {
+	createSvelteKitLayout,
+	createSvelteKitServerIntegration,
+	patchSvelteKitRenderModule,
+} from "./frameworks/sveltekit.js";
+import { createTanStackStartFramework } from "./frameworks/tanstack-start.js";
+import {
+	specializePerLocaleBundle,
+	validatePerLocaleBuildSettings,
+} from "./specialize-bundle.js";
+import { createPerLocaleBuildVitePlugin } from "./vite-plugin.js";
+import { getPerLocaleBuildLocaleId } from "./locale-id.js";
+import { getPerLocaleBuildPrefix } from "./frameworks/tanstack-start.js";
+
+const viteOxc = { version, minify, transformWithOxc };
+
+test("specializes the canonical client and emits non-base assets with identical filenames", async () => {
+	const bundle = createBundle({
+		"assets/app-deadbeef.js": localeBranchFixture,
+		"assets/app-deadbeef.css": "body { color: rebeccapurple }",
+	});
+
+	const result = await specializePerLocaleBundle({
+		bundle,
+		layout: createTanStackStartFramework().layout,
+		settings: { baseLocale: "en", locales: ["en", "de"] },
+		vite: viteOxc,
+	});
+
+	const canonical = bundle["assets/app-deadbeef.js"];
+	expect(canonical?.type).toBe("chunk");
+	if (canonical?.type !== "chunk") throw new Error("Expected a chunk");
+	expect(canonical.code).toContain("__SENTINEL_EN__");
+	expect(canonical.code).not.toContain("__SENTINEL_DE__");
+	expect(canonical.code).not.toContain(PER_LOCALE_BUILD_DEFINE);
+
+	const dePrefix = getPerLocaleBuildPrefix("de").replace(/^\//, "");
+	const deChunk = result.assets.find(
+		(asset) => asset.fileName === `${dePrefix}/assets/app-deadbeef.js`
+	);
+	expect(deChunk?.source.toString()).toContain("__SENTINEL_DE__");
+	expect(deChunk?.source.toString()).not.toContain("__SENTINEL_EN__");
+	expect(deChunk?.source.toString()).not.toContain(PER_LOCALE_BUILD_DEFINE);
+	expect(
+		result.assets.find(
+			(asset) => asset.fileName === `${dePrefix}/assets/app-deadbeef.css`
+		)?.source
+	).toBe("body { color: rebeccapurple }");
+
+	expect(result.manifest).toEqual({
+		version: 1,
+		baseLocale: "en",
+		locales: {
+			en: {
+				prefix: "",
+				assets: {
+					"/assets/app-deadbeef.css": "/assets/app-deadbeef.css",
+					"/assets/app-deadbeef.js": "/assets/app-deadbeef.js",
+				},
+			},
+			de: {
+				prefix: getPerLocaleBuildPrefix("de"),
+				assets: {
+					"/assets/app-deadbeef.css": `${getPerLocaleBuildPrefix("de")}/assets/app-deadbeef.css`,
+					"/assets/app-deadbeef.js": `${getPerLocaleBuildPrefix("de")}/assets/app-deadbeef.js`,
+				},
+			},
+		},
+	});
+});
+
+test("keeps localized CSS references closed and canonicalizes public assets", async () => {
+	const css = [
+		'@import "../public-theme.css";',
+		'@font-face { src: url("../public-font.woff2") }',
+		".emitted { src: url(./emitted-font.woff2?#iefix) }",
+		".external { src: url(https://cdn.example/font.woff2) }",
+	].join("\n");
+	const bundle = createBundle({
+		"assets/app.js": localeBranchFixture,
+		"assets/styles.css": css,
+		"assets/emitted-font.woff2": "emitted-font",
+	});
+
+	const result = await specializePerLocaleBundle({
+		bundle,
+		layout: createTanStackStartFramework().layout,
+		settings: { baseLocale: "en", locales: ["en", "de"] },
+		vite: viteOxc,
+	});
+
+	const expected = [
+		'@import "/public-theme.css";',
+		'@font-face { src: url("/public-font.woff2") }',
+		".emitted { src: url(./emitted-font.woff2?#iefix) }",
+		".external { src: url(https://cdn.example/font.woff2) }",
+	].join("\n");
+	const canonicalCss = bundle["assets/styles.css"];
+	expect(canonicalCss?.type).toBe("asset");
+	if (canonicalCss?.type !== "asset") throw new Error("Expected CSS asset");
+	expect(canonicalCss.source).toBe(expected);
+
+	const dePrefix = getPerLocaleBuildPrefix("de").replace(/^\//, "");
+	expect(
+		result.assets.find(
+			(asset) => asset.fileName === `${dePrefix}/assets/styles.css`
+		)?.source
+	).toBe(expected);
+	expect(
+		result.assets.find(
+			(asset) => asset.fileName === `${dePrefix}/assets/emitted-font.woff2`
+		)?.source
+	).toBe("emitted-font");
+});
+
+test("keeps SvelteKit locale copies inside its immutable cache directory", async () => {
+	const bundle = createBundle({
+		"_app/immutable/entry/app.js": localeBranchFixture,
+		"_app/immutable/assets/app.css":
+			'body { background: url("../../../favicon.png") }',
+		"_app/version.json": '{"version":"1"}',
+	});
+	const result = await specializePerLocaleBundle({
+		bundle,
+		layout: createSvelteKitLayout(),
+		settings: { baseLocale: "en", locales: ["en", "de"] },
+		vite: viteOxc,
+	});
+	const localizedRoot = "_app/immutable/__paraglide/de-6465";
+	expect(
+		result.assets
+			.find((asset) => asset.fileName === `${localizedRoot}/entry/app.js`)
+			?.source.toString()
+	).toContain("__SENTINEL_DE__");
+	expect(
+		result.assets.find(
+			(asset) => asset.fileName === `${localizedRoot}/assets/app.css`
+		)?.source
+	).toBe('body { background: url("/favicon.png") }');
+	expect(
+		result.assets.some((asset) => asset.fileName.includes("version.json"))
+	).toBe(false);
+	expect(result.manifest.locales.en).toEqual({
+		prefix: "",
+		assets: {
+			"/_app/immutable/assets/app.css": "/_app/immutable/assets/app.css",
+			"/_app/immutable/entry/app.js": "/_app/immutable/entry/app.js",
+			"/_app/version.json": "/_app/version.json",
+		},
+	});
+	expect(result.manifest.locales.de).toEqual({
+		prefix: `/${localizedRoot}`,
+		assets: {
+			"/_app/immutable/assets/app.css": `/${localizedRoot}/assets/app.css`,
+			"/_app/immutable/entry/app.js": `/${localizedRoot}/entry/app.js`,
+			"/_app/version.json": "/_app/version.json",
+		},
+	});
+});
+
+test("non-base JavaScript copies are emitted as assets, not entry chunks", async () => {
+	const plugin = createPerLocaleBuildVitePlugin({
+		settings: async () => ({ baseLocale: "en", locales: ["en", "de"] }),
+		generatedDirectory: "src/paraglide",
+		loadVite: async () => viteOxc,
+	});
+	const emitted: Array<Record<string, unknown>> = [];
+	const warnings: string[] = [];
+	const generateBundle = plugin.generateBundle;
+	if (!generateBundle || typeof generateBundle === "function") {
+		throw new Error("Expected an ordered generateBundle hook");
+	}
+	if (typeof plugin.configResolved !== "function") {
+		throw new Error("Expected configResolved hook");
+	}
+	plugin.configResolved.call(
+		{} as never,
+		{
+			plugins: [{ name: "tanstack-start-core:config" }],
+			define: {},
+			build: { ssr: false },
+		} as never
+	);
+
+	await generateBundle.handler.call(
+		{
+			environment: { config: { consumer: "client" } },
+			emitFile(file: Record<string, unknown>) {
+				emitted.push(file);
+				return "reference-id";
+			},
+			warn(message: string) {
+				warnings.push(message);
+			},
+		} as never,
+		{} as never,
+		createBundle({ "assets/app.js": localeBranchFixture }) as never,
+		false
+	);
+
+	const localizedJs = emitted.find(
+		(file) =>
+			typeof file.fileName === "string" && file.fileName.endsWith("/app.js")
+	);
+	expect(localizedJs).toMatchObject({ type: "asset" });
+	expect(localizedJs).not.toHaveProperty("isEntry");
+	expect(emitted).toContainEqual(
+		expect.objectContaining({
+			type: "asset",
+			fileName: PER_LOCALE_BUILD_MANIFEST,
+		})
+	);
+	const emittedManifest = emitted.find(
+		(file) => file.fileName === PER_LOCALE_BUILD_MANIFEST
+	);
+	expect(
+		JSON.parse(String(emittedManifest?.source)) as Record<string, unknown>
+	).toMatchObject({
+		version: 1,
+		baseLocale: "en",
+		locales: {
+			en: { prefix: "" },
+			de: { prefix: "/__paraglide/de-6465" },
+		},
+	});
+	expect(warnings).toEqual([]);
+});
+
+test("configures locale-safe asset URLs and reserves final minification", async () => {
+	const plugin = createPerLocaleBuildVitePlugin({
+		settings: async () => ({ baseLocale: "en", locales: ["en"] }),
+		generatedDirectory: "src/paraglide",
+	});
+	const config = plugin.config;
+	const configEnvironment = plugin.configEnvironment;
+	if (
+		!config ||
+		typeof config !== "function" ||
+		!configEnvironment ||
+		typeof configEnvironment !== "function"
+	) {
+		throw new Error("Expected Vite config hooks");
+	}
+	expect(() =>
+		config.call({} as never, { base: "/app/" }, { command: "build" } as never)
+	).toThrow("custom Vite base");
+	expect(() =>
+		config.call({} as never, { build: { minify: false } }, {
+			command: "build",
+		} as never)
+	).toThrow("requires client minification");
+	expect(() =>
+		config.call({} as never, { build: { sourcemap: true } }, {
+			command: "build",
+		} as never)
+	).toThrow("does not support client sourcemaps");
+	const configured = await config.call({} as never, {}, {
+		command: "build",
+	} as never);
+	if (!configured) throw new Error("Expected a Vite config result");
+	expect(configured).toMatchObject({ base: "" });
+	const renderBuiltUrl = configured?.experimental?.renderBuiltUrl;
+	if (!renderBuiltUrl) throw new Error("Expected renderBuiltUrl");
+	expect(
+		renderBuiltUrl("assets/styles.css", {
+			type: "asset",
+			hostId: "server.js",
+			hostType: "js",
+			ssr: true,
+		})
+	).toBe("/assets/styles.css");
+	expect(
+		renderBuiltUrl("assets/app.js", {
+			type: "asset",
+			hostId: "index.html",
+			hostType: "html",
+			ssr: false,
+		})
+	).toEqual({ relative: true });
+	expect(() =>
+		config.call(
+			{} as never,
+			{
+				experimental: {
+					renderBuiltUrl: () => "https://cdn.example/asset.js",
+				},
+			},
+			{ command: "build" } as never
+		)
+	).toThrow("cannot be combined with experimental.renderBuiltUrl");
+	expect(() =>
+		configEnvironment.call(
+			{} as never,
+			"client",
+			{ consumer: "client", build: { minify: "oxc", sourcemap: true } },
+			{ command: "build" } as never
+		)
+	).toThrow("does not support client sourcemaps");
+	expect(() =>
+		configEnvironment.call(
+			{} as never,
+			"client",
+			{ consumer: "client", build: { minify: false } },
+			{ command: "build" } as never
+		)
+	).toThrow("requires client minification");
+	expect(
+		configEnvironment.call(
+			{} as never,
+			"client",
+			{ build: { minify: "oxc" } },
+			{ command: "build" } as never
+		)
+	).toEqual({ build: { minify: false, sourcemap: false } });
+	expect(
+		configEnvironment.call({} as never, "ssr", { consumer: "server" }, {
+			command: "build",
+		} as never)
+	).toEqual({ define: { [PER_LOCALE_BUILD_DEFINE]: "undefined" } });
+	expect(
+		configEnvironment.call({} as never, "client", { consumer: "client" }, {
+			command: "serve",
+		} as never)
+	).toEqual({ define: { [PER_LOCALE_BUILD_DEFINE]: "undefined" } });
+});
+
+test.each(["7.3.0", "9.0.0"])(
+	"rejects unsupported Vite %s",
+	async (version) => {
+		await expect(
+			specializePerLocaleBundle({
+				bundle: createBundle({ "app.js": localeBranchFixture }),
+				layout: createTanStackStartFramework().layout,
+				settings: { baseLocale: "en", locales: ["en"] },
+				vite: {
+					...viteOxc,
+					version,
+				},
+			})
+		).rejects.toThrow("requires Vite 8");
+	}
+);
+
+test("detects TanStack Start and SvelteKit and rejects unsupported frameworks", () => {
+	expect(
+		detectPerLocaleBuildFramework({
+			plugins: [{ name: "tanstack-start-core:config" }],
+			define: {},
+		} as never)
+	).toHaveProperty("layout");
+	const svelteSetup = createSvelteKitSetup();
+	const svelte = detectPerLocaleBuildFramework({
+		plugins: [svelteSetup],
+		define: { __SVELTEKIT_APP_DIR__: '"_app"' },
+	} as never);
+	expect(svelte.layout).toBeDefined();
+	expect(() =>
+		detectPerLocaleBuildFramework({
+			plugins: [{ name: "vite-plugin-svelte" }],
+			define: {},
+		} as never)
+	).toThrow("supports TanStack Start and SvelteKit");
+	expect(() =>
+		detectPerLocaleBuildFramework({
+			plugins: [svelteSetup, { name: "tanstack-start-core:config" }],
+			define: {},
+		} as never)
+	).toThrow("both TanStack Start and SvelteKit");
+	for (const unsupported of [
+		{ appDir: "app" },
+		{ paths: { base: "/docs", assets: "" } },
+		{ output: { bundleStrategy: "inline" } },
+		{ router: { resolution: "server" } },
+		{ files: { serviceWorker: new URL(import.meta.url).pathname } },
+	]) {
+		expect(() =>
+			detectPerLocaleBuildFramework({
+				plugins: [createSvelteKitSetup(unsupported)],
+				define: {},
+			} as never)
+		).toThrow("supports only the tested SvelteKit 2.69.x defaults");
+	}
+
+	const plugin = createPerLocaleBuildVitePlugin({
+		settings: async () => ({ baseLocale: "en", locales: ["en"] }),
+		generatedDirectory: "src/paraglide",
+	});
+	const configResolved = plugin.configResolved;
+	if (!configResolved || typeof configResolved !== "function") {
+		throw new Error("Expected configResolved hook");
+	}
+
+	expect(() =>
+		configResolved.call({} as never, { plugins: [] } as never)
+	).toThrow("supports TanStack Start and SvelteKit");
+});
+
+test("guards multi-locale SvelteKit SPA fallbacks in the virtual adapter", async () => {
+	const plugin = createPerLocaleBuildVitePlugin({
+		settings: async () => ({ baseLocale: "en", locales: ["en", "de"] }),
+		generatedDirectory: "src/paraglide",
+	});
+	if (typeof plugin.configResolved !== "function") {
+		throw new Error("Expected configResolved hook");
+	}
+	plugin.configResolved.call(
+		{} as never,
+		{
+			root: "/app",
+			plugins: [createSvelteKitSetup()],
+			define: { __SVELTEKIT_APP_DIR__: '"_app"' },
+			build: { ssr: true },
+		} as never
+	);
+	if (typeof plugin.load !== "function") {
+		throw new Error("Expected load hook");
+	}
+	const source = await plugin.load.call(
+		{} as never,
+		"\0virtual:paraglide-per-locale-build/sveltekit"
+	);
+	expect(source).toContain("locales.length > 1");
+	expect(source).toContain("does not support SvelteKit SPA fallback pages");
+	expect(source).toContain('marker + "__paraglide/" + getLocaleId(locale)');
+	expect(source).not.toContain("per-locale-build.js");
+	if (typeof source !== "string") throw new Error("Expected virtual source");
+	const executableSource = source.replace(
+		/^import .*;$/m,
+		'const baseLocale = "en"; const locales = ["en", "de"]; let currentLocale = "de"; const getLocale = () => currentLocale; export const setTestLocale = (locale) => currentLocale = locale;'
+	);
+	const virtualModule = (await import(
+		`data:text/javascript;base64,${Buffer.from(executableSource).toString("base64")}`
+	)) as {
+		localizeSvelteKitAssetPath: (path: string) => string;
+		setTestLocale: (locale: string) => void;
+	};
+	const localized = `_app/immutable/__paraglide/${getPerLocaleBuildLocaleId("de")}/chunks/app.js`;
+	expect(
+		virtualModule.localizeSvelteKitAssetPath("_app/immutable/chunks/app.js")
+	).toBe(localized);
+	expect(virtualModule.localizeSvelteKitAssetPath(localized)).toBe(localized);
+	expect(virtualModule.localizeSvelteKitAssetPath("favicon.png")).toBe(
+		"favicon.png"
+	);
+	virtualModule.setTestLocale("en");
+	expect(
+		virtualModule.localizeSvelteKitAssetPath("_app/immutable/chunks/app.js")
+	).toBe("_app/immutable/chunks/app.js");
+	for (const locale of ["pt-BR", "中文", "en/us", "en?us"]) {
+		virtualModule.setTestLocale(locale);
+		expect(
+			virtualModule.localizeSvelteKitAssetPath("_app/immutable/chunks/app.js")
+		).toBe(
+			`_app/immutable/__paraglide/${getPerLocaleBuildLocaleId(locale)}/chunks/app.js`
+		);
+	}
+});
+
+test("patches SvelteKit asset rendering before preload and CSP generation", () => {
+	const render = patchSvelteKitRenderModule(`
+export async function render_response({ state }) {
+	if (state.prerendering) {
+		state.prerendering = true;
+	}
+const prefixed = (path) => {
+	return path;
+};
+}
+`);
+	expect(render).toContain(SVELTEKIT_VIRTUAL_IMPORT_SNIPPET);
+	expect(render).toContain(
+		"path = __paraglideLocalizeSvelteKitAssetPath(path);"
+	);
+	expect(render).toContain(
+		"__paraglideAssertSvelteKitPerLocaleFallbackSupported(state.prerendering?.fallback)"
+	);
+	expect(() => patchSvelteKitRenderModule("const changed = true;")).toThrow(
+		"differs from the tested SvelteKit 2.69.x"
+	);
+});
+
+test("requires the tested SvelteKit render module to be patched", () => {
+	const integration = createSvelteKitServerIntegration({
+		root: "/app",
+		generatedDirectory: "src/paraglide",
+	});
+	expect(() => integration.assertPatched()).toThrow(
+		"server rendering internals were not found"
+	);
+	integration.transform(
+		`export async function render_response({ state }) {
+	if (state.prerendering) {}
+	const prefixed = (path) => {
+		return path;
+	};
+}`,
+		"/node_modules/@sveltejs/kit/src/runtime/server/page/render.js"
+	);
+	expect(() => integration.assertPatched()).not.toThrow();
+});
+
+test("validates project locale invariants", () => {
+	expect(() =>
+		validatePerLocaleBuildSettings({ baseLocale: "en", locales: ["de"] })
+	).toThrow("is not present");
+	expect(() =>
+		validatePerLocaleBuildSettings({
+			baseLocale: "en",
+			locales: ["en", "en"],
+		})
+	).toThrow("unique");
+});
+
+function createBundle(files: Record<string, string>): OutputBundle {
+	return Object.fromEntries(
+		Object.entries(files).map(([fileName, source]) => {
+			if (fileName.endsWith(".js")) {
+				return [
+					fileName,
+					{
+						type: "chunk",
+						fileName,
+						name: "app",
+						code: source,
+						map: null,
+						imports: [],
+						dynamicImports: [],
+						exports: ["message"],
+						facadeModuleId: "/src/app.js",
+						isEntry: true,
+						isDynamicEntry: false,
+						moduleIds: ["/src/app.js"],
+						modules: {},
+						preliminaryFileName: fileName,
+						sourcemapFileName: null,
+					},
+				];
+			}
+			return [
+				fileName,
+				{
+					type: "asset",
+					fileName,
+					name: fileName,
+					names: [fileName],
+					originalFileName: null,
+					originalFileNames: [],
+					source,
+				},
+			];
+		})
+	) as unknown as OutputBundle;
+}
+
+function createSvelteKitSetup(overrides: Record<string, unknown> = {}) {
+	return {
+		name: "vite-plugin-sveltekit-setup",
+		api: {
+			options: {
+				kit: {
+					appDir: "_app",
+					output: { bundleStrategy: "split" },
+					paths: { base: "", assets: "" },
+					router: { resolution: "client" },
+					...overrides,
+				},
+			},
+		},
+	};
+}
+
+const localeBranchFixture = `
+const staticLocaleInput = ${PER_LOCALE_BUILD_DEFINE};
+const staticLocale = staticLocaleInput === undefined
+	? undefined
+	: staticLocaleInput === "en"
+		? "en"
+		: staticLocaleInput === "de"
+			? "de"
+			: staticLocaleInput;
+const en = () => "__SENTINEL_EN__";
+const de = () => "__SENTINEL_DE__";
+export const message = () => {
+	if (${PER_LOCALE_BUILD_DEFINE} === "en") return en();
+	if (${PER_LOCALE_BUILD_DEFINE} === "de") return de();
+	const locale = staticLocale ?? "en";
+	if (locale === "en") return en();
+	return de();
+};
+`;
+
+const SVELTEKIT_VIRTUAL_IMPORT_SNIPPET =
+	"virtual:paraglide-per-locale-build/sveltekit";

--- a/src/bundler-plugins/per-locale-build/vite-plugin.ts
+++ b/src/bundler-plugins/per-locale-build/vite-plugin.ts
@@ -1,0 +1,127 @@
+import type { Plugin } from "vite";
+import {
+	PER_LOCALE_BUILD_DEFINE,
+	PER_LOCALE_BUILD_MANIFEST,
+} from "./constants.js";
+import {
+	configurePerLocaleBuild,
+	detectPerLocaleBuildFramework,
+} from "./frameworks/index.js";
+import {
+	loadViteOxcApi,
+	specializePerLocaleBundle,
+} from "./specialize-bundle.js";
+import type {
+	PerLocaleBuildFramework,
+	PerLocaleBuildServerIntegration,
+	PerLocaleBuildSettings,
+	ViteOxcApi,
+} from "./types.js";
+
+export function createPerLocaleBuildVitePlugin(args: {
+	settings: () => Promise<PerLocaleBuildSettings>;
+	generatedDirectory: string;
+	loadVite?: () => Promise<ViteOxcApi>;
+	onFrameworkDetected?: (generatedFiles: Record<string, string>) => void;
+}): Plugin {
+	let framework: PerLocaleBuildFramework | undefined;
+	let serverIntegration: PerLocaleBuildServerIntegration | undefined;
+
+	return {
+		name: "paraglide-per-locale-build",
+		enforce: "post",
+		config(config, env) {
+			if (env.command !== "build") return;
+			if (![undefined, "", "/", "./"].includes(config.base)) {
+				throw new Error(
+					"experimentalPerLocaleBuild does not support a custom Vite base."
+				);
+			}
+			assertSupportedClientBuild(config.build);
+			return configurePerLocaleBuild(config);
+		},
+		configEnvironment(name, config, env) {
+			const isClient =
+				env.command === "build" &&
+				(config.consumer === "client" || name === "client");
+			if (!isClient) {
+				return {
+					define: { [PER_LOCALE_BUILD_DEFINE]: "undefined" },
+				};
+			}
+			assertSupportedClientBuild(config.build);
+			return { build: { minify: false, sourcemap: false } };
+		},
+		configResolved(config) {
+			framework = detectPerLocaleBuildFramework(config);
+			args.onFrameworkDetected?.(framework.generatedFiles ?? {});
+			serverIntegration = framework.createServerIntegration?.({
+				root: config.root,
+				generatedDirectory: args.generatedDirectory,
+			});
+		},
+		resolveId(id) {
+			return serverIntegration?.resolveId(id);
+		},
+		load(id) {
+			return serverIntegration?.load(id);
+		},
+		transform(code, id, options) {
+			if (!serverIntegration || options?.ssr === false) return;
+			return serverIntegration.transform(code, id);
+		},
+		generateBundle: {
+			order: "post",
+			async handler(_outputOptions, bundle) {
+				const isClient =
+					(
+						this as typeof this & {
+							environment: { config: { consumer?: "client" | "server" } };
+						}
+					).environment.config.consumer === "client";
+				if (!isClient) {
+					serverIntegration?.assertPatched();
+					return;
+				}
+				if (!framework) {
+					throw new Error(
+						"experimentalPerLocaleBuild could not identify the active framework."
+					);
+				}
+				const specialized = await specializePerLocaleBundle({
+					bundle,
+					layout: framework.layout,
+					settings: await args.settings(),
+					vite: await (args.loadVite ?? loadViteOxcApi)(),
+				});
+				for (const asset of specialized.assets) {
+					this.emitFile({
+						type: "asset",
+						fileName: asset.fileName,
+						source: asset.source,
+					});
+				}
+				this.emitFile({
+					type: "asset",
+					fileName: PER_LOCALE_BUILD_MANIFEST,
+					source: JSON.stringify(specialized.manifest, undefined, "\t") + "\n",
+				});
+			},
+		},
+	};
+}
+
+function assertSupportedClientBuild(
+	build:
+		| {
+				minify?: unknown;
+				sourcemap?: unknown;
+		  }
+		| undefined
+): void {
+	if (build?.minify === false || build?.sourcemap) {
+		throw new Error(
+			"experimentalPerLocaleBuild requires client minification and does not support client sourcemaps."
+		);
+	}
+}

--- a/src/bundler-plugins/vite.test.ts
+++ b/src/bundler-plugins/vite.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "vitest";
+import { memfs } from "memfs";
+import {
+	loadProjectInMemory,
+	newProject,
+	saveProjectToDirectory,
+} from "@inlang/sdk";
+import { paraglideVitePlugin } from "./vite.js";
+import { perLocaleBuildStaticLocaleExpression } from "../compiler/per-locale-build.js";
+
+test("experimentalPerLocaleBuild configures the compiler and emits the detected framework adapter", async () => {
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: { baseLocale: "en", locales: ["en", "de"] },
+		}),
+	});
+	const fs = memfs().fs as unknown as typeof import("node:fs");
+	await saveProjectToDirectory({
+		project,
+		path: "/project.inlang",
+		fs: fs.promises,
+	});
+
+	const plugins = paraglideVitePlugin({
+		project: "/project.inlang",
+		outdir: "/src/paraglide",
+		fs,
+		experimentalPerLocaleBuild: true,
+		additionalFiles: { "custom.js": "export const custom = true;\n" },
+	});
+	expect(Array.isArray(plugins)).toBe(true);
+	if (!Array.isArray(plugins))
+		throw new Error("Expected multiple Vite plugins");
+	expect(plugins.map((plugin) => plugin.name)).toEqual([
+		"unplugin-paraglide-js",
+		"paraglide-per-locale-build",
+	]);
+
+	const compiler = plugins[0]!;
+	const perLocaleBuild = plugins[1]!;
+	if (typeof perLocaleBuild.configResolved !== "function") {
+		throw new Error("Expected the per-locale configResolved hook");
+	}
+	perLocaleBuild.configResolved.call(
+		{} as never,
+		{
+			root: "/",
+			plugins: [{ name: "tanstack-start-core:config" }],
+			define: {},
+			build: { ssr: false },
+		} as never
+	);
+	if (typeof compiler.buildStart !== "function") {
+		throw new Error("Expected the compiler buildStart hook");
+	}
+	await compiler.buildStart.call({ addWatchFile() {} } as never, {} as never);
+
+	expect(
+		await fs.promises.readFile(
+			"/src/paraglide/tanstack-start.server.js",
+			"utf8"
+		)
+	).toContain("createStartHandler");
+	expect(
+		await fs.promises.readFile("/src/paraglide/custom.js", "utf8")
+	).toContain("export const custom = true;");
+	expect(
+		await fs.promises.readFile("/src/paraglide/runtime.js", "utf8")
+	).toContain(perLocaleBuildStaticLocaleExpression);
+});
+
+test("experimentalPerLocaleBuild rejects conflicting compiler options", () => {
+	const common = { project: "/project.inlang", outdir: "/src/paraglide" };
+	expect(() =>
+		paraglideVitePlugin({
+			...common,
+			experimentalPerLocaleBuild: true,
+			experimentalStaticLocale: '"de"',
+		})
+	).toThrow("cannot be combined with experimentalStaticLocale");
+	expect(() =>
+		paraglideVitePlugin({
+			...common,
+			experimentalPerLocaleBuild: true,
+			experimentalMiddlewareLocaleSplitting: true,
+		})
+	).toThrow("cannot be combined with experimentalMiddlewareLocaleSplitting");
+	expect(() =>
+		paraglideVitePlugin({
+			...common,
+			experimentalPerLocaleBuild: true,
+			outputStructure: "locale-modules",
+		})
+	).toThrow('requires outputStructure: "message-modules"');
+	expect(() =>
+		paraglideVitePlugin({
+			...common,
+			experimentalPerLocaleBuild: true,
+			strategy: ["preferredLanguage", "baseLocale"],
+		})
+	).toThrow('first locale strategy to be "url" or "cookie"');
+	expect(() =>
+		paraglideVitePlugin({
+			...common,
+			experimentalPerLocaleBuild: true,
+			routeStrategies: [],
+		})
+	).toThrow("does not support routeStrategies");
+	const plugins = paraglideVitePlugin({
+		...common,
+		experimentalPerLocaleBuild: true,
+		additionalFiles: { "tanstack-start.server.js": "user content" },
+	});
+	if (!Array.isArray(plugins)) {
+		throw new Error("Expected multiple Vite plugins");
+	}
+	const configResolved = plugins[1]?.configResolved;
+	if (typeof configResolved !== "function") {
+		throw new Error("Expected the per-locale configResolved hook");
+	}
+	expect(() =>
+		configResolved.call(
+			{} as never,
+			{
+				root: "/",
+				plugins: [{ name: "tanstack-start-core:config" }],
+				define: {},
+				build: { ssr: false },
+			} as never
+		)
+	).toThrow("additionalFiles already defines that path");
+});

--- a/src/bundler-plugins/vite.ts
+++ b/src/bundler-plugins/vite.ts
@@ -1,4 +1,36 @@
 import { createVitePlugin } from "unplugin";
+import type { Plugin } from "vite";
+import type { CompilerOptions } from "../compiler/compiler-options.js";
+import { createPerLocaleBuildPlugins } from "./per-locale-build/index.js";
 import { unpluginFactory } from "./unplugin.js";
 
-export const paraglideVitePlugin = createVitePlugin(unpluginFactory);
+export type ParaglideVitePluginOptions = CompilerOptions & {
+	/**
+	 * Emit one compiler-specialized client asset tree per project locale.
+	 *
+	 * Supports the documented default configurations of TanStack Start and
+	 * SvelteKit on Vite 8.x. Unsupported framework and asset configurations fail
+	 * during the build. Locale changes need to use full-document navigation.
+	 *
+	 * @experimental
+	 * @default false
+	 */
+	experimentalPerLocaleBuild?: boolean;
+};
+
+const createCompilerVitePlugin = createVitePlugin(unpluginFactory);
+
+export function paraglideVitePlugin(
+	options: ParaglideVitePluginOptions
+): Plugin | Plugin[] {
+	const { experimentalPerLocaleBuild, ...compilerOptions } = options;
+	if (!experimentalPerLocaleBuild) {
+		return createCompilerVitePlugin(compilerOptions) as Plugin;
+	}
+
+	return createPerLocaleBuildPlugins({
+		compilerOptions,
+		createCompilerPlugin: (options) =>
+			createCompilerVitePlugin(options) as Plugin,
+	});
+}

--- a/src/compiler/compile-bundle.test.ts
+++ b/src/compiler/compile-bundle.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "vitest";
 import { compileBundle, toBundleInputTypeAliasName } from "./compile-bundle.js";
 import type { BundleNested, ProjectSettings } from "@inlang/sdk";
 import { toSafeModuleId } from "./safe-module-id.js";
+import { perLocaleBuildStaticLocaleExpression } from "./per-locale-build.js";
 
 test("compiles to jsdoc", async () => {
 	const mockBundle: BundleNested = {
@@ -74,7 +75,9 @@ test("emits middleware locale splitting hooks when enabled", () => {
 				bundleId: "blue_moon_bottle",
 				locale: "en",
 				selectors: [],
-				variants: [{ id: "1", messageId: "message-id", matches: [], pattern: [] }],
+				variants: [
+					{ id: "1", messageId: "message-id", matches: [], pattern: [] },
+				],
 			},
 		],
 	};
@@ -93,8 +96,65 @@ test("emits middleware locale splitting hooks when enabled", () => {
 	expect(result.bundle.code).toContain(
 		"if (experimentalMiddlewareLocaleSplitting && isServer === false)"
 	);
-	expect(result.bundle.code).toContain("trackMessageCall(\"blue_moon_bottle\", locale)");
-	expect(result.bundle.code).toContain("globalThis).__paraglide.ssr.blue_moon_bottle(inputs)");
+	expect(result.bundle.code).toContain(
+		'trackMessageCall("blue_moon_bottle", locale)'
+	);
+	expect(result.bundle.code).toContain(
+		"globalThis).__paraglide.ssr.blue_moon_bottle(inputs)"
+	);
+});
+
+test("emits the per-locale build marker inside the message function", () => {
+	const mockBundle: BundleNested = {
+		id: "greeting",
+		declarations: [],
+		messages: [
+			{
+				id: "greeting-en",
+				bundleId: "greeting",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "greeting-en-variant",
+						messageId: "greeting-en",
+						matches: [],
+						pattern: [{ type: "text", value: "hello" }],
+					},
+				],
+			},
+			{
+				id: "greeting-de",
+				bundleId: "greeting",
+				locale: "de",
+				selectors: [],
+				variants: [
+					{
+						id: "greeting-de-variant",
+						messageId: "greeting-de",
+						matches: [],
+						pattern: [{ type: "text", value: "hallo" }],
+					},
+				],
+			},
+		],
+	};
+	const expression = perLocaleBuildStaticLocaleExpression;
+	const result = compileBundle({
+		bundle: mockBundle,
+		fallbackMap: { en: undefined, de: "en" },
+		messageReferenceExpression: (locale) => `${locale}_greeting`,
+		settings: { locales: ["en", "de"] } as ProjectSettings,
+		experimentalStaticLocale: expression,
+	});
+
+	expect(result.bundle.code).toContain(
+		`const locale = ${expression} ?? options.locale ?? getLocale()`
+	);
+	expect(result.bundle.code).toContain(
+		`if (${expression} !== undefined && options.locale !== undefined && options.locale !== ${expression}) console.warn(`
+	);
+	expect(result.bundle.code).toContain("full document navigation");
 });
 
 test("compiles to jsdoc with missing translation", async () => {
@@ -255,9 +315,7 @@ test("handles message pattern with duplicate variable references", async () => {
 	});
 
 	// The JSDoc should not have duplicate parameters
-	expect(result.bundle.code).toContain(
-		"@param {Date_Last_DaysInputs} inputs"
-	);
+	expect(result.bundle.code).toContain("@param {Date_Last_DaysInputs} inputs");
 	expect(result.bundle.code).not.toContain(
 		"days: NonNullable<unknown>, days: NonNullable<unknown>"
 	);
@@ -286,13 +344,23 @@ test("adds .parts() to bundle functions when markup exists", async () => {
 						messageId: "notice-id",
 						matches: [],
 						pattern: [
-							{ type: "markup-start", name: "strong", options: [], attributes: [] },
+							{
+								type: "markup-start",
+								name: "strong",
+								options: [],
+								attributes: [],
+							},
 							{
 								type: "expression",
 								arg: { type: "variable-reference", name: "count" },
 							},
 							{ type: "text", value: " items" },
-							{ type: "markup-end", name: "strong", options: [], attributes: [] },
+							{
+								type: "markup-end",
+								name: "strong",
+								options: [],
+								attributes: [],
+							},
 						],
 					},
 				],

--- a/src/compiler/compile-bundle.ts
+++ b/src/compiler/compile-bundle.ts
@@ -16,6 +16,8 @@ import {
 import { isValidIdentifier, quotePropertyKey } from "./variable-access.js";
 import { toSafeModuleId } from "./safe-module-id.js";
 import { escapeForDoubleQuoteString } from "../services/codegen/escape.js";
+import type { CompilerOptions } from "./compiler-options.js";
+import { perLocaleBuildStaticLocaleExpression } from "./per-locale-build.js";
 
 export type CompiledBundleWithMessages = {
 	/** The compilation result for the bundle index */
@@ -39,6 +41,7 @@ export const compileBundle = (args: {
 	messageReferenceExpression: (locale: string, bundleId: string) => string;
 	settings?: ProjectSettings;
 	experimentalMiddlewareLocaleSplitting?: boolean;
+	experimentalStaticLocale?: CompilerOptions["experimentalStaticLocale"];
 }): CompiledBundleWithMessages => {
 	const compiledMessages: Record<string, Compiled<Message>> = {};
 	const safeBundleId = toSafeModuleId(args.bundle.id);
@@ -73,6 +76,7 @@ export const compileBundle = (args: {
 			hasMarkup,
 			experimentalMiddlewareLocaleSplitting:
 				args.experimentalMiddlewareLocaleSplitting ?? false,
+			experimentalStaticLocale: args.experimentalStaticLocale,
 			inputTypeAliasName,
 		}),
 		messages: compiledMessages,
@@ -110,6 +114,11 @@ const compileBundleFunction = (args: {
 	 * Whether middleware locale splitting runtime hooks should be emitted.
 	 */
 	experimentalMiddlewareLocaleSplitting: boolean;
+	/**
+	 * Static locale expression emitted inside the message function so a
+	 * chunk-local minifier can specialize its locale branches.
+	 */
+	experimentalStaticLocale?: CompilerOptions["experimentalStaticLocale"];
 	/**
 	 * Shared typedef name for bundle input types used across emitted JSDoc.
 	 */
@@ -197,16 +206,25 @@ ${englishMatchTableDoc}${jsDocBundleFunctionTypes({
 		return `\n${indent}trackMessageCall("${safeBundleId}", locale)`;
 	};
 
+	const perLocaleBuild =
+		args.experimentalStaticLocale === perLocaleBuildStaticLocaleExpression;
 	const localeResolutionStatement = (indent: string): string => {
+		const localeExpression = perLocaleBuild
+			? `${perLocaleBuildStaticLocaleExpression} ?? options.locale ?? getLocale()`
+			: "experimentalStaticLocale ?? options.locale ?? getLocale()";
+		const overrideWarning = perLocaleBuild
+			? `\n${indent}if (${perLocaleBuildStaticLocaleExpression} !== undefined && options.locale !== undefined && options.locale !== ${perLocaleBuildStaticLocaleExpression}) console.warn("Paraglide: options.locale cannot override a locale-specialized client bundle; use a full document navigation to switch locales.")`
+			: "";
+
 		if (
 			isFullyTranslated &&
 			args.availableLocales.length === 1 &&
 			!args.experimentalMiddlewareLocaleSplitting
 		) {
-			return `${indent}experimentalStaticLocale ?? options.locale ?? getLocale()`;
+			return `${indent}${localeExpression}${overrideWarning}`;
 		}
 
-		return `${indent}const locale = experimentalStaticLocale ?? options.locale ?? getLocale()${maybeTrackMessageCall(
+		return `${indent}const locale = ${localeExpression}${overrideWarning}${maybeTrackMessageCall(
 			indent
 		)}`;
 	};

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -17,6 +17,8 @@ import {
 import { compileProject, getFallbackMap } from "./compile-project.js";
 import virtual from "@rollup/plugin-virtual";
 import { rolldown } from "rolldown";
+import { minify, transformWithOxc } from "vite";
+import { perLocaleBuildStaticLocaleExpression } from "./per-locale-build.js";
 
 beforeEach(() => {
 	// reset the imports to make sure that the runtime is reloaded
@@ -104,6 +106,38 @@ test("emits messages/package.json with sideEffects:false for message-modules", a
 
 	// scoped to message-modules (the structure with the re-export barrel)
 	expect(localeModules).not.toHaveProperty("messages/package.json");
+});
+
+test("Oxc specializes a bundled message to one locale", async () => {
+	const expression = perLocaleBuildStaticLocaleExpression;
+	const output = await compileProject({
+		project,
+		compilerOptions: {
+			experimentalStaticLocale: expression,
+		},
+	});
+	const bundled = await bundleCode(
+		output,
+		`import { sad_penguin_bundle } from "./paraglide/messages.js";
+		console.log(sad_penguin_bundle());`
+	);
+	const transformed = await transformWithOxc(bundled, "message-chunk.js", {
+		lang: "js",
+		sourceType: "module",
+		define: {
+			"globalThis.__PARAGLIDE_STATIC_LOCALE__": JSON.stringify("de"),
+		},
+		sourcemap: false,
+	});
+	const specialized = await minify("message-chunk.js", transformed.code, {
+		module: true,
+		compress: true,
+		mangle: true,
+	});
+
+	expect(specialized.errors).toEqual([]);
+	expect(specialized.code).toContain("Eine einfache Nachricht.");
+	expect(specialized.code).not.toContain("A simple message.");
 });
 
 test("emitPrettierIgnore", async () => {

--- a/src/compiler/compile-project.ts
+++ b/src/compiler/compile-project.ts
@@ -57,6 +57,10 @@ export const compileProject = async (args: {
 			settings,
 			experimentalMiddlewareLocaleSplitting:
 				optionsWithDefaults.experimentalMiddlewareLocaleSplitting,
+			experimentalStaticLocale:
+				optionsWithDefaults.outputStructure === "message-modules"
+					? optionsWithDefaults.experimentalStaticLocale
+					: undefined,
 		})
 	);
 

--- a/src/compiler/output-structure/message-modules.test.ts
+++ b/src/compiler/output-structure/message-modules.test.ts
@@ -117,8 +117,12 @@ test("emits minimal runtime imports when middleware splitting is disabled", () =
 	expect(output["messages/happy_elephant.js"]).toContain(
 		"import { getLocale, experimentalStaticLocale } from '../runtime.js';"
 	);
-	expect(output["messages/happy_elephant.js"]).not.toContain("trackMessageCall");
-	expect(output["messages/happy_elephant.js"]).not.toContain("experimentalMiddlewareLocaleSplitting");
+	expect(output["messages/happy_elephant.js"]).not.toContain(
+		"trackMessageCall"
+	);
+	expect(output["messages/happy_elephant.js"]).not.toContain(
+		"experimentalMiddlewareLocaleSplitting"
+	);
 	expect(output["messages/happy_elephant.js"]).not.toContain("isServer");
 });
 

--- a/src/compiler/per-locale-build.ts
+++ b/src/compiler/per-locale-build.ts
@@ -1,0 +1,3 @@
+/** Internal compiler/bundler contract for locale-specialized client builds. */
+export const perLocaleBuildStaticLocaleExpression =
+	"/** @type {any} */ (globalThis).__PARAGLIDE_STATIC_LOCALE__";

--- a/src/compiler/runtime/create-runtime.ts
+++ b/src/compiler/runtime/create-runtime.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import type { CompilerOptions } from "../compiler-options.js";
+import { perLocaleBuildStaticLocaleExpression } from "../per-locale-build.js";
 
 /**
  * Returns the code for the `runtime.js` module
@@ -132,7 +133,12 @@ ${injectCode("./variables.js")
 	.replace(
 		`export const experimentalStaticLocale = undefined;`,
 		args.compilerOptions.experimentalStaticLocale
-			? `export const experimentalStaticLocale = assertIsLocale(${args.compilerOptions.experimentalStaticLocale});`
+			? `export const experimentalStaticLocale = ${
+					args.compilerOptions.experimentalStaticLocale ===
+					perLocaleBuildStaticLocaleExpression
+						? args.compilerOptions.experimentalStaticLocale
+						: `assertIsLocale(${args.compilerOptions.experimentalStaticLocale})`
+				};`
 			: `export const experimentalStaticLocale = undefined;`
 	)
 	.replace(

--- a/src/compiler/runtime/set-locale.js
+++ b/src/compiler/runtime/set-locale.js
@@ -9,6 +9,7 @@ import {
 	getStrategyForUrl,
 	isServer,
 	localStorageKey,
+	experimentalStaticLocale,
 	strategy,
 	TREE_SHAKE_COOKIE_STRATEGY_USED,
 	TREE_SHAKE_GLOBAL_VARIABLE_STRATEGY_USED,
@@ -61,6 +62,16 @@ export let setLocale = (newLocale, options) => {
 		reload: true,
 		...options,
 	};
+	if (
+		experimentalStaticLocale !== undefined &&
+		newLocale !== experimentalStaticLocale &&
+		optionsWithDefaults.reload === false
+	) {
+		console.warn(
+			`Paraglide: setLocale(${JSON.stringify(newLocale)}, { reload: false }) cannot switch away from the statically built locale ${JSON.stringify(experimentalStaticLocale)}. A document navigation is required; reload has been forced to true.`
+		);
+		optionsWithDefaults.reload = true;
+	}
 	// locale is already set
 	// https://github.com/opral/inlang-paraglide-js/issues/430
 	/** @type {Locale | undefined} */

--- a/src/compiler/runtime/set-locale.test.ts
+++ b/src/compiler/runtime/set-locale.test.ts
@@ -337,6 +337,40 @@ test("should not reload when setting locale to current locale", async () => {
 	expect(globalThis.window.location.reload).toBeCalled();
 });
 
+test("static locale builds force a document reload when switching locales", async () => {
+	// @ts-expect-error - browser shim for tests
+	globalThis.document = { cookie: "" };
+	globalThis.window = {
+		location: {
+			href: "https://example.com/en",
+			hostname: "example.com",
+			reload: vi.fn(),
+		},
+	} as any;
+	const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+	try {
+		const runtime = await createParaglide({
+			blob: await newProject({
+				settings: {
+					baseLocale: "en",
+					locales: ["en", "de"],
+				},
+			}),
+			strategy: ["cookie"],
+			isServer: "false",
+			experimentalStaticLocale: JSON.stringify("en"),
+		});
+
+		runtime.setLocale("de", { reload: false });
+
+		expect(warn).toHaveBeenCalledOnce();
+		expect(globalThis.window.location.reload).toHaveBeenCalledOnce();
+	} finally {
+		warn.mockRestore();
+	}
+});
+
 test("sets the locale to localStorage", async () => {
 	// @ts-expect-error - global variable definition
 	globalThis.localStorage = {


### PR DESCRIPTION
## Summary

- add `experimentalPerLocaleBuild: true` to the Vite plugin for TanStack Start and SvelteKit
- specialize the client bundle once per project locale using Vite 8's Oxc transform/minify APIs
- emit a canonical base-locale graph, isolated non-base locale asset trees, and `paraglide-per-locale.json`
- generate the TanStack Start server entry and integrate SvelteKit SSR/prerender asset selection
- force full-navigation locale changes for statically specialized clients

This is an experimental, compiler-based path toward per-locale splitting for #88. The server bundle remains shared; only client message branches and their reachable code are specialized per locale.

## Supported envelope

The flag deliberately fails early outside the tested 90% configuration:

- Vite 8 only
- root/default asset hosting
- global locale strategy beginning with `url` or `cookie`
- client minification enabled and client sourcemaps disabled
- TanStack Start 1.168.x using the generated server entry
- SvelteKit 2.69.x defaults: `_app`, split bundles, client router resolution, SSR/prerender, and no service worker

Custom Vite bases, `routeStrategies`, external asset URLs, custom `renderBuiltUrl`, SvelteKit SPA fallbacks, and non-default SvelteKit asset/router layouts are rejected rather than supported implicitly.

## Validation

- `pnpm test` — 167 test files passed; 1,568 tests passed and 28 skipped
- TanStack Start production client and SSR build on Vite 8.1.4
- SvelteKit production client and SSR build on Vite 8.1.4
- SvelteKit per-locale verifier covering isolated locale graphs, prerender output, live SSR asset URLs, Link headers, shared server output, and closed imports
- `pnpm check` in the SvelteKit example — zero errors and warnings
- TypeScript, formatting, lint, and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches client bundling, SSR/prerender asset URL rewriting, and framework-specific server hooks—misconfiguration or edge setups could break production i18n or caching despite fail-fast checks.
> 
> **Overview**
> Introduces **`experimentalPerLocaleBuild: true`** on `paraglideVitePlugin`, which on **Vite 8** builds a separate client asset graph per project locale by specializing compiled messages at build time (Oxc transform/minify). The **base locale** keeps canonical URLs; other locales get isolated trees (TanStack Start under `/__paraglide/<locale-id>/`, SvelteKit under `/_app/immutable/__paraglide/<locale-id>/`) plus **`paraglide-per-locale.json`** for prefixes and asset mappings.
> 
> **TanStack Start** must re-export the generated **`tanstack-start.server.js`** entry (middleware + per-request client asset selection). **SvelteKit** keeps `paraglideMiddleware` in hooks; the plugin patches renderer integration for SSR, prerender, Link headers, and bootstrap imports. Locale switches require **full navigation** (`setLocale()` default, `data-sveltekit-reload` on cross-locale links); runtime warns and ignores conflicting `options.locale` on specialized clients.
> 
> The feature is **fail-fast** outside a narrow envelope (tested framework versions, strategy starting with `url`/`cookie`, no `routeStrategies`, default asset hosting, no client source maps / `minify: false`, etc.). Examples and docs are updated; the SvelteKit example adds **`verify-per-locale-build.mjs`** and **`vite`** is declared an optional peer dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42efb02877584ed6c28efaad484384eccfd4707e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->