### PR TITLE
Recommend TypeScript declarations in framework setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,16 @@ import { paraglideVitePlugin } from "@inlang/paraglide-js";
 export default defineConfig({
   plugins: [
     react(),
-    paraglideVitePlugin({ project: "./project.inlang", outdir: "./src/paraglide" }),
+    paraglideVitePlugin({
+      project: "./project.inlang",
+      outdir: "./src/paraglide",
+      emitTsDeclarations: true,
+    }),
   ],
 });
 ```
+
+`emitTsDeclarations` requires TypeScript 5.6 or newer and keeps editor types in sync when message files change. Set it to `false` to use the faster JavaScript/JSDoc inference path instead.
 
 The `Greeting` component shown above is all the app code you need. `setLocale()` reloads the page by default so every message re-renders — a deliberate design choice: a user switches language once, so a reload keeps things simple and avoids framework-specific state/scroll-preservation logic (the same approach YouTube and others take). Pass `setLocale("de", { reload: false })` to drive re-rendering yourself.
 

--- a/docs-api/compiler-options.md
+++ b/docs-api/compiler-options.md
@@ -40,7 +40,7 @@ The output will look like this:
 
 > `optional` **cleanOutdir**: `boolean`
 
-Defined in: [compiler-options.ts:386](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:392](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Whether to clean the output directory before writing the new files.
 
@@ -111,7 +111,7 @@ The name of the cookie to use for the cookie strategy.
 
 > `optional` **disableAsyncLocalStorage**: `boolean`
 
-Defined in: [compiler-options.ts:315](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:321](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Replaces AsyncLocalStorage with a synchronous implementation.
 
@@ -128,7 +128,7 @@ one request could leak into another concurrent request.
 
 > `optional` **emitGitIgnore**: `boolean`
 
-Defined in: [compiler-options.ts:329](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:335](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 If `emitGitIgnore` is set to `true` a `.gitignore` file will be emitted in the output directory. Defaults to `true`.
 
@@ -197,17 +197,23 @@ true
 
 > `optional` **emitTsDeclarations**: `boolean`
 
-Defined in: [compiler-options.ts:292](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:298](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Emit `.d.ts` files for the generated output using the TypeScript compiler.
 
 Useful when `allowJs: true` cannot be set in your `tsconfig.json`
-(e.g., due to project constraints or conflicting compiler options).
+(e.g., due to project constraints or conflicting compiler options), or when
+an editor language server caches stale JSDoc types for generated messages.
 
 Requires `typescript` to be resolvable in your toolchain.
 
 **Note:** Enabling this option reduces compiler speed because TypeScript
 needs to generate declaration files for all output modules.
+
+**Note:** With TypeScript 5/6 the declarations are generated in-process.
+TypeScript 7+ no longer provides the compiler API, so its `tsc` CLI is
+invoked in a child process instead; the emitted declarations are
+semantically equivalent but differ cosmetically between the two.
 
 ##### Example
 
@@ -297,7 +303,7 @@ https://github.com/opral/paraglide-js/issues/88#issuecomment-3634754638
 
 > `optional` **fs**: `any`
 
-Defined in: [compiler-options.ts:393](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:399](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 The file system to use. Defaults to `await import('node:fs')`.
 
@@ -307,7 +313,7 @@ Useful for testing the paraglide compiler by mocking the fs.
 
 > `optional` **includeEslintDisableComment**: `boolean`
 
-Defined in: [compiler-options.ts:302](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:308](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 Whether to include an eslint-disable comment at the top of each .js file.
 
@@ -376,7 +382,7 @@ await compile({
 
 > `optional` **outputStructure**: `"locale-modules"` \| `"message-modules"`
 
-Defined in: [compiler-options.ts:380](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:386](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 The `outputStructure` defines how modules are structured in the output.
 
@@ -501,7 +507,7 @@ Custom strategies with the pattern `custom-[A-Za-z0-9]+` are supported.
 
 > `optional` **urlPatterns**: [`Runtime`](runtime/type/README.md#runtime)\[`"urlPatterns"`\]
 
-Defined in: [compiler-options.ts:296](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
+Defined in: [compiler-options.ts:302](https://github.com/opral/paraglide-js/tree/main/src/compiler/compiler-options.ts)
 
 https://paraglidejs.com/strategy#url
 

--- a/docs/compiling-messages.md
+++ b/docs/compiling-messages.md
@@ -21,16 +21,18 @@ For all available options, see the [Compiler Options Reference](./compiler-optio
 > [!TIP]
 > For a complete setup guide using CLI compilation with Express, Hono, Fastify, or Elysia, see [Standalone Servers](./standalone-servers). For monorepo setups, see [Monorepo Setup](./monorepo).
 
+The recommended commands below emit `.d.ts` files for reliable editor updates and require TypeScript 5.6 or newer. Omit `--emit-ts-declarations` to use JavaScript/JSDoc inference instead.
+
 To compile your messages via the CLI, run the following command:
 
 ```bash
-npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/paraglide
+npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations
 ```
 
 To watch files and recompile on change, add the `--watch` flag:
 
 ```bash
-npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --watch
+npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations --watch
 ```
 
 Use `--help` to see all available options:
@@ -71,6 +73,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
+			emitTsDeclarations: true,
 		}),
 	],
 });
@@ -144,6 +147,7 @@ module.exports = {
 		paraglideWebpackPlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
+			emitTsDeclarations: true,
 		}),
 	],
 };
@@ -160,6 +164,7 @@ export default {
 		paraglideRollupPlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
+			emitTsDeclarations: true,
 		}),
 	],
 };
@@ -167,7 +172,9 @@ export default {
 
 ## TypeScript Configuration
 
-Paraglide compiles to JavaScript with JSDoc type annotations, providing full type safety without a separate build step. To enable TypeScript support for JSDoc types, add `allowJs` to your `tsconfig.json`:
+Paraglide compiles to JavaScript with JSDoc type annotations. The recommended configurations above also emit `.d.ts` files so editors reliably refresh message keys when generated files change. Declaration emission requires TypeScript 5.6 or newer.
+
+If you disable declaration emission for faster compilation, enable TypeScript support for the generated JSDoc types with `allowJs` in your `tsconfig.json`:
 
 ```json
 {
@@ -179,10 +186,10 @@ Paraglide compiles to JavaScript with JSDoc type annotations, providing full typ
 
 ### Emitting `.d.ts` declarations
 
-If your project doesn't support `allowJs` (e.g., publishing a library), you can emit TypeScript declaration files instead:
+Emit TypeScript declaration files when your project doesn't support `allowJs` (e.g., publishing a library), or when your editor reports newly added message functions as missing until its language server restarts:
 
 ```bash
-npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emitTsDeclarations
+npx @inlang/paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --emit-ts-declarations
 ```
 
 Or via bundler plugin / programmatic API:
@@ -196,7 +203,7 @@ paraglideVitePlugin({
 ```
 
 > [!NOTE]
-> Emitting declarations requires the `typescript` package and is slower than JSDoc-based types. Use `allowJs: true` when possible for faster compilation.
+> Emitting declarations requires TypeScript 5.6 or newer and is slower than JSDoc-based types. The framework setup examples enable it for reliable language-server updates. Set `emitTsDeclarations: false` (or use `--no-emit-ts-declarations`) and `allowJs: true` when faster compilation matters more in your project.
 
 > [!NOTE]
 > With TypeScript 5 and 6, declarations are generated with the in-process compiler API. TypeScript 7+ no longer provides that API, so Paraglide invokes its `tsc` CLI in a child process instead. The output is semantically equivalent, but differs cosmetically between the two (quote style, declaration ordering, `export declare const` vs `export const`) — expect `.d.ts` churn when switching TypeScript majors.
@@ -239,6 +246,7 @@ import { compile } from "@inlang/paraglide-js";
 await compile({
 	project: "./project.inlang",
 	outdir: "./src/paraglide",
+	emitTsDeclarations: true,
 });
 ```
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -294,6 +294,7 @@ Request A (locale: de) ───────────────────
 paraglideVitePlugin({
 	project: "./project.inlang",
 	outdir: "./src/paraglide",
+	emitTsDeclarations: true,
 	disableAsyncLocalStorage: true, // Compatibility fallback
 });
 ```
@@ -373,6 +374,7 @@ Ensure AsyncLocalStorage is enabled (the default):
 paraglideVitePlugin({
 	project: "./project.inlang",
 	outdir: "./src/paraglide",
+	emitTsDeclarations: true,
 	// Don't set this to true unless your runtime lacks AsyncLocalStorage
 	// and guarantees per-request isolation
 	// disableAsyncLocalStorage: true,
@@ -449,6 +451,7 @@ defineCustomServerStrategy("custom-database", {
 paraglideVitePlugin({
 	project: "./project.inlang",
 	outdir: "./src/paraglide",
+	emitTsDeclarations: true,
 	strategy: ["custom-header", "url", "cookie", "baseLocale"],
 });
 ```

--- a/docs/static-site-generation.md
+++ b/docs/static-site-generation.md
@@ -188,6 +188,7 @@ export default defineConfig({
       paraglideVitePlugin({
         project: "./project.inlang",
         outdir: "./src/paraglide",
+        emitTsDeclarations: true,
         strategy: ["url", "globalVariable", "baseLocale"],
       }),
     ],
@@ -253,6 +254,7 @@ SSG typically requires all locales to have a URL prefix so each locale generates
 compile({
   project: "./project.inlang",
   outdir: "./src/paraglide",
+  emitTsDeclarations: true,
   strategy: ["url", "globalVariable", "baseLocale"],
   urlPatterns: [
     {

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -44,6 +44,7 @@ export default defineConfig({
 +			paraglideVitePlugin({
 +				project: "./project.inlang",
 +				outdir: "./src/paraglide",
++				emitTsDeclarations: true,
 +			}),
 +		],
 	},

--- a/examples/astro/astro.config.mjs
+++ b/examples/astro/astro.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig({
 			paraglideVitePlugin({
 				project: "./project.inlang",
 				outdir: "./src/paraglide",
+				emitTsDeclarations: true,
 				strategy: ["url"],
 			}),
 		],

--- a/examples/incremental-migration/vite.config.js
+++ b/examples/incremental-migration/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
+			emitTsDeclarations: true,
 		}),
 	],
 	build: {

--- a/examples/next-js-ssg/README.md
+++ b/examples/next-js-ssg/README.md
@@ -46,6 +46,7 @@ export default {
 +			paraglideWebpackPlugin({
 +				outdir: "./src/paraglide",
 +				project: "./project.inlang",
++				emitTsDeclarations: true,
 +       strategy: ["url", "cookie", "baseLocale"],
 +				urlPatterns: [
 +					{

--- a/examples/next-js-ssg/next.config.mjs
+++ b/examples/next-js-ssg/next.config.mjs
@@ -9,6 +9,7 @@ export default {
 			paraglideWebpackPlugin({
 				outdir: "./src/paraglide",
 				project: "./project.inlang",
+				emitTsDeclarations: true,
 				strategy: ["url", "cookie", "baseLocale"],
 				urlPatterns: [
 					{

--- a/examples/next-js-ssg/package.json
+++ b/examples/next-js-ssg/package.json
@@ -14,7 +14,7 @@
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "workspace:*",
-		"typescript": "^5",
+		"typescript": "^5.6.0",
 		"@types/node": "^20",
 		"@types/react": "^19",
 		"@types/react-dom": "^19"

--- a/examples/next-js-ssr/README.md
+++ b/examples/next-js-ssr/README.md
@@ -46,6 +46,7 @@ export default {
 +			paraglideWebpackPlugin({
 +				outdir: "./src/paraglide",
 +				project: "./project.inlang",
++				emitTsDeclarations: true,
 +       strategy: ["url", "cookie", "baseLocale"],
 +			})
 +		);

--- a/examples/next-js-ssr/next.config.mjs
+++ b/examples/next-js-ssr/next.config.mjs
@@ -9,6 +9,7 @@ export default {
 			paraglideWebpackPlugin({
 				outdir: "./src/paraglide",
 				project: "./project.inlang",
+				emitTsDeclarations: true,
 				strategy: ["url", "cookie", "baseLocale"],
 			})
 		);

--- a/examples/next-js-ssr/package.json
+++ b/examples/next-js-ssr/package.json
@@ -14,7 +14,7 @@
 	},
 	"devDependencies": {
 		"@inlang/paraglide-js": "workspace:*",
-		"typescript": "^5",
+		"typescript": "^5.6.0",
 		"@types/node": "^20",
 		"@types/react": "^19",
 		"@types/react-dom": "^19"

--- a/examples/react-router/README.md
+++ b/examples/react-router/README.md
@@ -36,6 +36,7 @@ export default defineConfig({
 +		paraglideVitePlugin({
 +			project: "./project.inlang",
 +			outdir: "./app/paraglide",
++			emitTsDeclarations: true,
 +		}),
 	],
 });
@@ -141,6 +142,7 @@ Keep the corresponding Paraglide `urlPatterns` so helpers like
 paraglideVitePlugin({
 	project: "./project.inlang",
 	outdir: "./app/paraglide",
+	emitTsDeclarations: true,
 	strategy: ["url", "baseLocale"],
 	urlPatterns: [
 		{

--- a/examples/react-router/vite.config.ts
+++ b/examples/react-router/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: "./project.inlang",
 			outdir: "./app/paraglide",
+			emitTsDeclarations: true,
 			strategy: ["url", "baseLocale"],
 		}),
 	],

--- a/examples/react/vite.config.js
+++ b/examples/react/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: "./project.inlang",
 			outdir: "./src/paraglide",
+			emitTsDeclarations: true,
 		}),
 	],
 });

--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -47,12 +47,15 @@ export default defineConfig({
 +		paraglideVitePlugin({
 +			project: './project.inlang',
 +			outdir: './src/lib/paraglide',
++			emitTsDeclarations: true,
 +			experimentalPerLocaleBuild: true,
 +			strategy: ['url', 'cookie', 'baseLocale'],
 +		})
 	]
 });
 ```
+
+`emitTsDeclarations` keeps the Svelte and TypeScript language servers in sync when you add or rename message keys while the dev server is running.
 
 #### Add `%lang%` and `%dir%` to `src/app.html`.
 

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -22,7 +22,7 @@
 		"prettier-plugin-svelte": "^3.4.1",
 		"svelte": "^5.56.4",
 		"svelte-check": "^4.3.5",
-		"typescript": "^5.0.0",
+		"typescript": "^5.6.0",
 		"vite": "^8.1.4"
 	}
 }

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: './project.inlang',
 			outdir: './src/lib/paraglide',
+			emitTsDeclarations: true,
 			experimentalPerLocaleBuild: true,
 			strategy: ['url', 'cookie', 'baseLocale']
 		})

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -49,6 +49,7 @@ export default defineConfig({
 +              paraglideVitePlugin({
 +                      project: "./project.inlang",
 +                      outdir: "./src/paraglide",
++     emitTsDeclarations: true,
 +                      experimentalPerLocaleBuild: true,
 +     outputStructure: "message-modules",
 +     cookieName: "PARAGLIDE_LOCALE",

--- a/examples/tanstack-start/vite.config.ts
+++ b/examples/tanstack-start/vite.config.ts
@@ -12,6 +12,7 @@ const config = defineConfig({
     paraglideVitePlugin({
       project: './project.inlang',
       outdir: './src/paraglide',
+      emitTsDeclarations: true,
       experimentalPerLocaleBuild: true,
       outputStructure: 'message-modules',
       cookieName: 'PARAGLIDE_LOCALE',

--- a/examples/vite/README.md
+++ b/examples/vite/README.md
@@ -63,6 +63,7 @@ export default defineConfig({
 +    paraglideVitePlugin({
 +      project: "./project.inlang",
 +      outdir: "./src/paraglide",
++      emitTsDeclarations: true,
 +    }),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         specifier: ^4.3.5
         version: 4.3.5(picomatch@4.0.3)(svelte@5.56.4)(typescript@5.8.3)
       typescript:
-        specifier: ^5.0.0
+        specifier: ^5.6.0
         version: 5.8.3
       vite:
         specifier: ^8.1.4

--- a/src/compiler/compile-project.test.ts
+++ b/src/compiler/compile-project.test.ts
@@ -319,9 +319,10 @@ test("emitTsDeclarations generates declaration files", async () => {
 	tsProject.createSourceFile(
 		"test.ts",
 		`
-			import { relative_time_dynamic } from "./messages.js";
+			import { m, relative_time_dynamic } from "./messages.js";
 			import { relativetime } from "./registry.js";
 
+			m.sad_penguin_bundle() satisfies string;
 			relative_time_dynamic({ duration: -3, unit: "hour" }) satisfies string;
 			relativetime("en", -3, { unit: "hour", style: "short" }) satisfies string;
 		`
@@ -333,6 +334,13 @@ test("emitTsDeclarations generates declaration files", async () => {
 		console.error(diagnostic.messageText, diagnostic.file?.fileName);
 	}
 	expect(diagnostics.length).toEqual(0);
+});
+
+test("emitTsDeclarations remains opt-in", async () => {
+	const output = await compileProject({ project });
+	expect(
+		Object.keys(output).some((fileName) => fileName.endsWith(".d.ts"))
+	).toBe(false);
 });
 
 test("emitTsDeclarations quotes unsafe export aliases", async () => {

--- a/src/compiler/compiler-options.ts
+++ b/src/compiler/compiler-options.ts
@@ -271,7 +271,8 @@ export type CompilerOptions = {
 	 * Emit `.d.ts` files for the generated output using the TypeScript compiler.
 	 *
 	 * Useful when `allowJs: true` cannot be set in your `tsconfig.json`
-	 * (e.g., due to project constraints or conflicting compiler options).
+	 * (e.g., due to project constraints or conflicting compiler options), or when
+	 * an editor language server caches stale JSDoc types for generated messages.
 	 *
 	 * Requires `typescript` to be resolvable in your toolchain.
 	 *


### PR DESCRIPTION
## Summary

- enable `emitTsDeclarations` in recommended framework configurations and examples, including SvelteKit, TanStack Start, React/Vite, React Router, Astro, Next/Webpack, and static-site generation
- document the TypeScript 5.6 requirement and the explicit opt-out
- exercise the generated `m.*` declaration namespace while keeping the compiler default opt-in

## Why

Generated JavaScript/JSDoc exports can remain stale in long-lived TypeScript and Svelte language-server sessions after message keys change. Emitting explicit declaration files gives the language server an authoritative watched type surface.

This changes the recommended setup only; it does not change the compiler-wide default.

## Validation

- `pnpm run build`
- `pnpm exec vitest run src/compiler/compile-project.test.ts src/bundler-plugins/unplugin.test.ts`
- `pnpm run build:examples`
- syntax-checked the Next.js SSR and SSG configs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, example config, and test-only changes; no change to compiler defaults or runtime behavior.
> 
> **Overview**
> **Recommends `emitTsDeclarations: true`** across README, compiling guides, middleware/SSG docs, and framework example configs (Vite, Webpack, SvelteKit, TanStack Start, Next.js, Astro, React Router, etc.) so editors pick up new message keys without stale JSDoc. Docs now call out **TypeScript 5.6+**, the **`--emit-ts-declarations` CLI flag**, and how to opt out for faster JSDoc/`allowJs` builds.
> 
> **Compiler behavior is unchanged** (`emitTsDeclarations` still defaults to `false`). Option docs explain language-server staleness and TS 5/6 vs 7+ declaration emission. Tests assert declarations stay opt-in and type-check the generated **`m.*`** namespace when enabled. Example apps bump **`typescript` to `^5.6.0`** where declarations are used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234d5611cdda60f386bf490d4cc682f397f6705b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->