### PR TITLE
chore: use example.com for placeholder URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@
 ## Opening a PR
 
 1. Run `pnpm run ci` to run all tests and checks.
-2. Run `pnpm dlx changeset` to write a changelog and trigger a version bump. Watch [this video](https://www.loom.com/share/1c5467ae3a5243d79040fc3eb5aa12d6) to see how to use changesets.
+2. Run `pnpm exec changeset` to write a changelog and trigger a version bump. Watch [this video](https://www.loom.com/share/1c5467ae3a5243d79040fc3eb5aa12d6) to see how to use changesets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 - [Node.js](https://nodejs.org/en/) (v20 or higher)
 - [pnpm](https://pnpm.io/) (v8 or higher)
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > If you are developing on Windows, you need to use [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux).
 
 ## Development
@@ -19,4 +19,4 @@
 ## Opening a PR
 
 1. Run `pnpm run ci` to run all tests and checks.
-2. Run `npx changeset` to write a changelog and trigger a version bump. Watch [this video](https://www.loom.com/share/1c5467ae3a5243d79040fc3eb5aa12d6) to see how to use changesets.
+2. Run `pnpm dlx changeset` to write a changelog and trigger a version bump. Watch [this video](https://www.loom.com/share/1c5467ae3a5243d79040fc3eb5aa12d6) to see how to use changesets.

--- a/docs-api/runtime/type/-internal-.md
+++ b/docs-api/runtime/type/-internal-.md
@@ -228,7 +228,7 @@ Defined in: [runtime/variables.js:132](https://github.com/opral/paraglide-js/tre
 
 > **SetLocaleFn**\<\> = (`newLocale`, `options?`) => `void` \| `Promise`\<`void`\>
 
-Defined in: [runtime/set-locale.js:34](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:36](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
 
 ### Type Parameters
 
@@ -629,7 +629,7 @@ deLocalizeUrl(url); // => URL("https://example.com/store")
 
 > **extractLocaleFromCookie**(): `undefined` \| `string`
 
-Defined in: [runtime/extract-locale-from-cookie.js:12](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/extract-locale-from-cookie.js)
+Defined in: [runtime/extract-locale-from-cookie.js:36](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/extract-locale-from-cookie.js)
 
 Extracts a cookie from the document.
 
@@ -994,7 +994,7 @@ Defined in: [runtime/get-url-origin.js:12](https://github.com/opral/paraglide-js
 
 The origin of the current URL.
 
-Defaults to "http://y.com" in non-browser environments. If this
+Defaults to "http://example.com" in non-browser environments. If this
 behavior is not desired, the implementation can be overwritten
 by `overwriteGetUrlOrigin()`.
 
@@ -1288,7 +1288,7 @@ avoid a circular import between `runtime.js` and
 
 > **overwriteSetLocale**(`fn`): `void`
 
-Defined in: [runtime/set-locale.js:181](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:194](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
 
 Overwrite the `setLocale()` function.
 
@@ -1320,7 +1320,7 @@ overwriteSetLocale((newLocale) => {
 
 > **setLocale**(`newLocale`, `options?`): `void` \| `Promise`\<`void`\>
 
-Defined in: [runtime/set-locale.js:58](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:60](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
 
 Set the locale.
 

--- a/src/compiler/runtime/extract-locale-from-url.js
+++ b/src/compiler/runtime/extract-locale-from-url.js
@@ -68,7 +68,7 @@ export function extractLocaleFromUrl(url) {
  * @returns {Locale | undefined} The extracted locale, or undefined if no locale is found.
  */
 function defaultUrlPatternExtractLocale(url) {
-	const urlObj = new URL(url, "http://dummy.com");
+	const urlObj = new URL(url, "http://example.com");
 	const pathSegments = urlObj.pathname.split("/").filter(Boolean);
 	return toLocale(pathSegments[0]) || baseLocale;
 }

--- a/src/compiler/runtime/get-url-origin.js
+++ b/src/compiler/runtime/get-url-origin.js
@@ -3,7 +3,7 @@ import { serverAsyncLocalStorage } from "./variables.js";
 /**
  * The origin of the current URL.
  *
- * Defaults to "http://y.com" in non-browser environments. If this
+ * Defaults to "http://example.com" in non-browser environments. If this
  * behavior is not desired, the implementation can be overwritten
  * by `overwriteGetUrlOrigin()`.
  *

--- a/src/compiler/runtime/variables.js
+++ b/src/compiler/runtime/variables.js
@@ -74,7 +74,7 @@ function findMatchingRouteStrategy(url) {
 		return cachedRouteStrategy;
 	}
 
-	const urlObject = new URL(urlString, "http://dummy.com");
+	const urlObject = new URL(urlString, "http://example.com");
 	let match;
 	for (const routeStrategy of routeStrategies) {
 		const pattern = new URLPattern(routeStrategy.match, urlObject.href);


### PR DESCRIPTION
Replace placeholder URLs (`dummy.com`, `y.com`) with the standard reserved domain `example.com` per [RFC2606](https://datatracker.ietf.org/doc/html/rfc2606).