### PR TITLE
docs: clarify locale switching uses document navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ export default defineConfig({
 
 The `Greeting` component shown above is all the app code you need. By default, `setLocale()` updates the selection through your configured strategies and performs a full document navigation: it navigates to the localized URL when URL routing is enabled, or reloads the current document otherwise. The new document renders the app and any document-level locale settings together, with no i18n provider or framework reactivity to wire up.
 
+For the deliberately narrow browser-only `setLocale(locale, { reload: false })` escape hatch, see [the warning in Basics](https://paraglidejs.com/basics#advanced-stay-on-the-current-document). It is for a fully client-rendered, non-URL surface that must preserve non-restorable in-memory work and transfers all reactive and document-state updates to the application.
+
 **[Full React + Vite example →](https://github.com/opral/paraglide-js/tree/main/examples/react)** · **[React Router (SSR) guide →](https://paraglidejs.com/react-router)**
 
 ## SSR Ready

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ export default defineConfig({
 
 `emitTsDeclarations` requires TypeScript 5.6 or newer and keeps editor types in sync when message files change. Set it to `false` to use the faster JavaScript/JSDoc inference path instead.
 
-The `Greeting` component shown above is all the app code you need. `setLocale()` reloads the page by default so every message re-renders — a deliberate design choice: a user switches language once, so a reload keeps things simple and avoids framework-specific state/scroll-preservation logic (the same approach YouTube and others take). Pass `setLocale("de", { reload: false })` to drive re-rendering yourself.
+The `Greeting` component shown above is all the app code you need. By default, `setLocale()` updates the selection through your configured strategies and performs a full document navigation: it navigates to the localized URL when URL routing is enabled, or reloads the current document otherwise. The new document renders the app and any document-level locale settings together, with no i18n provider or framework reactivity to wire up.
 
 **[Full React + Vite example →](https://github.com/opral/paraglide-js/tree/main/examples/react)** · **[React Router (SSR) guide →](https://paraglidejs.com/react-router)**
 
@@ -221,7 +221,7 @@ m.greeting({ name: "Ada" });
 
 // Get/set locale
 getLocale(); // "en"
-setLocale("de"); // switches to German
+setLocale("de"); // loads the German document
 ```
 
 **[Full Getting Started Guide →](https://paraglidejs.com)**

--- a/docs-api/runtime/type/-internal-.md
+++ b/docs-api/runtime/type/-internal-.md
@@ -1288,7 +1288,7 @@ avoid a circular import between `runtime.js` and
 
 > **overwriteSetLocale**(`fn`): `void`
 
-Defined in: [runtime/set-locale.js:194](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:197](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
 
 Overwrite the `setLocale()` function.
 
@@ -1320,14 +1320,17 @@ overwriteSetLocale((newLocale) => {
 
 > **setLocale**(`newLocale`, `options?`): `void` \| `Promise`\<`void`\>
 
-Defined in: [runtime/set-locale.js:60](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
+Defined in: [runtime/set-locale.js:63](https://github.com/opral/paraglide-js/tree/main/src/compiler/runtime/set-locale.js)
 
 Set the locale.
 
 Updates the locale using your configured strategies (cookie, localStorage, URL, etc.).
-By default, this reloads the page on the client to reflect the new locale. Reloading
-can be disabled by passing `reload: false` as an option, but you'll need to ensure
-the UI updates to reflect the new locale.
+By default, this navigates the client to the localized URL or reloads the current
+document to reflect the new locale. `reload: false` is a narrow browser-only escape
+hatch for a fully client-rendered, non-URL-routed surface that owns its reactive
+updates and document state. It does not re-render the UI or update the document.
+Do not use it for normal locale pickers, URL-routed pages, or switching an SSR,
+SSG, or hydrated document. It is incompatible with per-locale builds.
 
 If any custom strategy's `setLocale` function is async, then this function
 will become async as well.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -40,6 +40,19 @@ setLocale("de"); // Updates the locale and starts a document navigation
 > [!NOTE]
 > Locale switching uses a full document navigation, not framework reactivity. By default, `setLocale()` updates the configured locale strategies and then navigates to the localized URL when URL routing is enabled; otherwise, it reloads the current document. The new document renders the app and any document-level locale settings together.
 
+### Advanced: stay on the current document
+
+> [!WARNING]
+> `setLocale(locale, { reload: false })` is a client-only escape hatch, not a normal locale picker. It updates the configured locale strategies but does not re-render your framework, navigate to the localized URL, or update document state such as `<html lang>`, `dir`, title, or metadata.
+>
+> Use it only for a fully client-rendered surface that you own and that must preserve non-restorable in-memory work—for example, an embedded widget, browser-extension options page, or persistent authoring or real-time workspace. If a custom strategy makes `setLocale()` asynchronous, await it before triggering every locale-dependent UI update through your own reactive state and synchronizing the document or root state you own.
+>
+> Do **not** use it for an ordinary locale picker or to switch an SSR-, SSG-, or hydrated document. Never use it on a route whose active locale strategy includes `url`, or with `experimentalPerLocaleBuild`. With the `url` strategy, it leaves the old URL and document shell in place, so `getLocale()` can keep resolving the old locale; use a full document navigation instead.
+
+```js
+await setLocale("de", { reload: false });
+```
+
 ## Forcing a locale
 
 Override the locale for a specific message:

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -34,19 +34,11 @@ import { getLocale, getTextDirection, setLocale } from "./paraglide/runtime.js";
 
 getLocale(); // "en"
 getTextDirection(); // "ltr" or "rtl" for current locale
-setLocale("de"); // Changes locale and reloads page
+setLocale("de"); // Updates the locale and starts a document navigation
 ```
 
 > [!NOTE]
-> `setLocale()` triggers a page reload by default. This is a deliberate design choice that keeps the implementation simple without framework-specific logic for preserving form state, scroll position, etc. A user switches the language once, so optimizing for instant locale switching is a poor trade-off. YouTube and other major sites work the same way.
-
-To change without reload:
-
-```js
-setLocale("de", { reload: false });
-```
-
-You'll need to trigger a re-render of your component tree using your framework's reactivity (e.g., React state, Svelte stores, Vue refs).
+> Locale switching uses a full document navigation, not framework reactivity. By default, `setLocale()` updates the configured locale strategies and then navigates to the localized URL when URL routing is enabled; otherwise, it reloads the current document. The new document renders the app and any document-level locale settings together.
 
 ## Forcing a locale
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -229,7 +229,7 @@ m.personal_balance({ amount: 1000.57 }, { locale: "en" }); // "Your balance is 1
 m.personal_balance({ amount: 1000.57 }, { locale: "de" }); // "Ihr Kontostand ist 1.000,57."
 ```
 
-For a locale picker, use `setLocale()` and let it navigate to the locale's document. See [Basics](./basics#getting-and-setting-the-locale).
+For a locale picker, use `setLocale()` and let it navigate to the locale's document. Do not use `reload: false` for a preview: the per-message `locale` option above is designed for that. See [Basics](./basics#getting-and-setting-the-locale).
 
 ## Common mistakes
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -216,24 +216,20 @@ m.relative_update(relative);
 
 Paraglide uses the platform `Intl.RelativeTimeFormat`. Older runtimes need a polyfill.
 
-## Locale changes and reactivity
+## Formatting across locales
 
-Formatting runs when message functions are called. If locale changes, formatted values update the next time the message is evaluated.
+Formatting runs when a message function is called. On a page, messages use the current document's locale. Changing the user's locale starts a new document navigation, so formatting runs again as the new document renders.
+
+To format a value for a locale other than the current document—for example, in a preview or server response—pass that locale to the message call:
 
 ```ts
 import { m } from "./paraglide/messages.js";
-import { setLocale } from "./paraglide/runtime.js";
 
-setLocale("en");
-m.personal_balance({ amount: 1000.57 }); // "Your balance is 1,000.57."
-
-setLocale("de");
-m.personal_balance({ amount: 1000.57 }); // "Your balance is 1.000,57."
+m.personal_balance({ amount: 1000.57 }, { locale: "en" }); // "Your balance is 1,000.57."
+m.personal_balance({ amount: 1000.57 }, { locale: "de" }); // "Ihr Kontostand ist 1.000,57."
 ```
 
-By default, `setLocale()` reloads the page. If you pass `{ reload: false }`, trigger re-rendering with your framework's own reactivity.
-
-See [Basics](./basics#getting-and-setting-the-locale) for details.
+For a locale picker, use `setLocale()` and let it navigate to the locale's document. See [Basics](./basics#getting-and-setting-the-locale).
 
 ## Common mistakes
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -218,7 +218,7 @@ Paraglide uses the platform `Intl.RelativeTimeFormat`. Older runtimes need a pol
 
 ## Formatting across locales
 
-Formatting runs when a message function is called. On a page, messages use the current document's locale. Changing the user's locale starts a new document navigation, so formatting runs again as the new document renders.
+Formatting runs when a message function is called. On a page, messages use the current document's locale. By default, changing the user's locale starts a new document navigation, so formatting runs again as the new document renders. The rare browser-only `setLocale(locale, { reload: false })` escape hatch stays on the current document instead; it does not automatically re-run formatting calls, so the application must update its locale-dependent UI. See [the warning in Basics](./basics#advanced-stay-on-the-current-document).
 
 To format a value for a locale other than the current document—for example, in a preview or server response—pass that locale to the message call:
 

--- a/docs/i18n-routing.md
+++ b/docs/i18n-routing.md
@@ -409,9 +409,11 @@ export const beforeLoad = async ({ location }) => {
 
 If you need to re-sync the URL after client-side navigations in SvelteKit, put `shouldRedirect()` in the root `+layout.svelte`. This only affects the client after hydration. The initial SSR document request is still handled by `paraglideMiddleware()`.
 
+Treat every resulting redirect as a document navigation, including same-origin URLs. Do not use SvelteKit's `goto()` for a locale-changing redirect: a full navigation ensures document-level state such as `<html lang>` and `dir`, server-rendered data, and client state all match the new locale.
+
 ```svelte
 <script lang="ts">
-	import { afterNavigate, goto } from "$app/navigation";
+	import { afterNavigate } from "$app/navigation";
 	import { onMount } from "svelte";
 	import { shouldRedirect } from "$lib/paraglide/runtime";
 
@@ -419,12 +421,7 @@ If you need to re-sync the URL after client-side navigations in SvelteKit, put `
 		const decision = await shouldRedirect({ url });
 
 		if (decision.shouldRedirect && decision.redirectUrl) {
-			if (decision.redirectUrl.origin !== window.location.origin) {
-				window.location.href = decision.redirectUrl.href;
-				return;
-			}
-
-			await goto(decision.redirectUrl, { invalidateAll: true });
+			window.location.href = decision.redirectUrl.href;
 		}
 	}
 
@@ -438,6 +435,7 @@ If you need to re-sync the URL after client-side navigations in SvelteKit, put `
 		}
 	});
 </script>
+```
 
 #### Server Behind a Proxy
 

--- a/docs/i18n-routing.md
+++ b/docs/i18n-routing.md
@@ -411,6 +411,9 @@ If you need to re-sync the URL after client-side navigations in SvelteKit, put `
 
 Treat every resulting redirect as a document navigation, including same-origin URLs. Do not use SvelteKit's `goto()` for a locale-changing redirect: a full navigation ensures document-level state such as `<html lang>` and `dir`, server-rendered data, and client state all match the new locale.
 
+> [!WARNING]
+> This is intentionally not a use case for `setLocale(..., { reload: false })`. A locale-changing URL must load a new document; that escape hatch or SvelteKit's `goto()` can retain a stale document shell.
+
 ```svelte
 <script lang="ts">
 	import { afterNavigate } from "$app/navigation";

--- a/docs/paraglide-vs-react-i18next.md
+++ b/docs/paraglide-vs-react-i18next.md
@@ -75,7 +75,9 @@ Paraglide generates the message functions, so keys and parameters are typed by d
 
 react-i18next changes the language in the running React tree when you call `i18n.changeLanguage()`.
 
-Paraglide treats a locale change as a **full document navigation**. By default, `setLocale()` updates the configured locale strategies, then navigates to the localized URL when URL routing is enabled or reloads the current document otherwise. The new document renders the app and any document-level locale settings together, without an i18n provider or reactive locale state in React. See [the basics](https://paraglidejs.com/basics).
+Paraglide treats a locale change as a **full document navigation**. By default, `setLocale()` updates the configured locale strategies, then navigates to the localized URL when URL routing is enabled or reloads the current document otherwise. The new document renders the app and any document-level locale settings together, without an i18n provider or reactive locale state in React.
+
+The rare browser-only `reload: false` escape hatch is for a fully client-rendered, non-URL surface that must preserve non-restorable in-memory work; it makes React reactivity and document-state synchronization the application's responsibility. See [the warning in Basics](https://paraglidejs.com/basics#advanced-stay-on-the-current-document).
 
 ## Rich text (the `<Trans>` use case)
 

--- a/docs/paraglide-vs-react-i18next.md
+++ b/docs/paraglide-vs-react-i18next.md
@@ -73,9 +73,9 @@ Paraglide generates the message functions, so keys and parameters are typed by d
 
 ## Locale switching in React
 
-react-i18next re-renders subscribed components via `useTranslation()` when you call `i18n.changeLanguage()`.
+react-i18next changes the language in the running React tree when you call `i18n.changeLanguage()`.
 
-Paraglide's `setLocale()` **reloads the page by default** so every message re-renders in the new locale — no provider or context to wire up. This is a deliberate design choice: a user switches language once, so a reload keeps the implementation simple and avoids framework-specific logic for preserving form state, scroll position, and the like (the same approach YouTube and other large sites take). If you'd rather drive re-rendering yourself, pass `setLocale("de", { reload: false })`. See [the basics](https://paraglidejs.com/basics).
+Paraglide treats a locale change as a **full document navigation**. By default, `setLocale()` updates the configured locale strategies, then navigates to the localized URL when URL routing is enabled or reloads the current document otherwise. The new document renders the app and any document-level locale settings together, without an i18n provider or reactive locale state in React. See [the basics](https://paraglidejs.com/basics).
 
 ## Rich text (the `<Trans>` use case)
 

--- a/docs/static-site-generation.md
+++ b/docs/static-site-generation.md
@@ -157,13 +157,13 @@ import { defineMiddleware } from "astro:middleware";
 import { assertIsLocale, baseLocale, setLocale } from "./paraglide/runtime.js";
 
 export const onRequest = defineMiddleware((context, next) => {
-  setLocale(assertIsLocale(context.currentLocale ?? baseLocale), {
-    reload: false,
-  });
+  setLocale(assertIsLocale(context.currentLocale ?? baseLocale));
 
   return next();
 });
 ```
+
+This runs during server-side static rendering, so `setLocale()` does not navigate a browser. The browser-only `reload: false` escape hatch is not needed here.
 
 Do not use `paraglideMiddleware()` for Astro SSG. The server middleware
 de-localizes request URLs for SSR, while static pages need Astro to render each

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -213,7 +213,9 @@ Because the client and server have separate Paraglide runtimes, you will need to
 
 Use `overwriteGetLocale()` to read the locale from a cookie, HTTP header, or i18n routing. On the client, keep the default `setLocale()` behavior whenever possible: it updates the configured strategies and then performs a full document navigation or reload.
 
-If you need `overwriteSetLocale()` to persist a locale outside the configured strategies, make the client-side locale change a full document navigation after persisting it. Do not use the override to trigger a reactive application re-render; document navigation keeps document-level state, server rendering, and client state in sync.
+If you need `overwriteSetLocale()` to persist a locale outside the configured strategies, make the client-side locale change a full document navigation after persisting it. Do not use an override to turn ordinary URL-routed or SSR locale changes into a reactive application re-render; document navigation keeps document-level state, server rendering, and client state in sync.
+
+The built-in `setLocale(locale, { reload: false })` option is a deliberately narrow escape hatch for a fully client-rendered surface whose active strategy does not include `url` and that owns its complete reactive shell. It is not a reason to recreate reactive locale switching with an override; see [the warning in Basics](./basics#advanced-stay-on-the-current-document).
 
 _Read the [architecture documentation](https://paraglidejs.com/architecture) to learn more about's Paraglide's inner workings._
 

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -204,17 +204,16 @@ Rules:
 
 Write your own cookie, http header, or i18n routing based locale strategy to integrate Paraglide into any framework or app.
 
-Only two APIs are needed to define this behaviour and adapt Paraglide JS to your requirements:
+Two override APIs are available to adapt Paraglide JS to your requirements:
 
 - `overwriteGetLocale` defines the `getLocale()` function that messages use to determine the locale
-- `overwriteSetLocale` defines the `setLocale()` function that apps call to change the locale
+- `overwriteSetLocale` replaces the `setLocale()` function that apps call to change the locale
 
 Because the client and server have separate Paraglide runtimes, you will need to define these behaviours separately on the client and server.
 
-The steps are usually the same, irrespective of the strategy and framework you use:
+Use `overwriteGetLocale()` to read the locale from a cookie, HTTP header, or i18n routing. On the client, keep the default `setLocale()` behavior whenever possible: it updates the configured strategies and then performs a full document navigation or reload.
 
-1. Use `overwriteGetLocale()` function that reads the locale from a cookie, HTTP header, or i18n routing.
-2. Handle any side effects of changing the locale and trigger a re-render in your application via `overwriteSetLocale()` (for many apps, this may only be required on the client side).
+If you need `overwriteSetLocale()` to persist a locale outside the configured strategies, make the client-side locale change a full document navigation after persisting it. Do not use the override to trigger a reactive application re-render; document navigation keeps document-level state, server rendering, and client state in sync.
 
 _Read the [architecture documentation](https://paraglidejs.com/architecture) to learn more about's Paraglide's inner workings._
 

--- a/src/compiler/runtime/set-locale.js
+++ b/src/compiler/runtime/set-locale.js
@@ -40,9 +40,12 @@ const navigateOrReload = (newLocation) => {
  * Set the locale.
  *
  * Updates the locale using your configured strategies (cookie, localStorage, URL, etc.).
- * By default, this reloads the page on the client to reflect the new locale. Reloading
- * can be disabled by passing `reload: false` as an option, but you'll need to ensure
- * the UI updates to reflect the new locale.
+ * By default, this navigates the client to the localized URL or reloads the current
+ * document to reflect the new locale. `reload: false` is a narrow browser-only escape
+ * hatch for a fully client-rendered, non-URL-routed surface that owns its reactive
+ * updates and document state. It does not re-render the UI or update the document.
+ * Do not use it for normal locale pickers, URL-routed pages, or switching an SSR,
+ * SSG, or hydrated document. It is incompatible with per-locale builds.
  *
  * If any custom strategy's `setLocale` function is async, then this function
  * will become async as well.


### PR DESCRIPTION
## Summary

- keep full document navigation as the default locale-switching path
- document `setLocale(locale, { reload: false })` as a deliberately narrow browser-only escape hatch
- require application-owned UI and document-state synchronization for that escape hatch, and explicitly exclude URL-routed, SSR/SSG/hydrated, and per-locale-build document switches
- use per-message locale options for formatting previews instead of reactive app-wide switching
- make the SvelteKit URL-sync recipe use document navigation for every locale-changing redirect
- align the API reference and remove the unnecessary server-side SSG `reload: false` option

## Why

A no-navigation switch does not re-render the framework or update document state. With the active `url` strategy, it also leaves the old URL in place, so the locale resolver can continue to read the old locale. The escape hatch is therefore only appropriate for a client-owned surface that must preserve non-restorable in-memory work, such as an isolated widget or persistent authoring workspace.

## Validation

- `pnpm generate-api-docs`
- `pnpm --filter @inlang/paraglide-js-website test`
- `pnpm --filter @inlang/paraglide-js-website build`