### PR TITLE
fix: use base locale as exhaustive message branch

### DIFF
--- a/.changeset/calm-locales-fallback.md
+++ b/.changeset/calm-locales-fallback.md
@@ -1,0 +1,5 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+Use `baseLocale` as the exhaustive branch in generated message functions.

--- a/src/compiler/compile-bundle.test.ts
+++ b/src/compiler/compile-bundle.test.ts
@@ -65,6 +65,53 @@ test("compiles to jsdoc", async () => {
 	);
 });
 
+test("uses the base locale as the exhaustive locale branch", () => {
+	const mockBundle: BundleNested = {
+		id: "greeting",
+		declarations: [],
+		messages: [
+			{
+				id: "message-id",
+				bundleId: "greeting",
+				locale: "en",
+				selectors: [],
+				variants: [
+					{
+						id: "variant-id",
+						messageId: "message-id",
+						matches: [],
+						pattern: [{ type: "text", value: "Hello" }],
+					},
+				],
+			},
+		],
+	};
+
+	const result = compileBundle({
+		fallbackMap: {
+			fr: "en",
+			de: "en",
+			en: undefined,
+			ja: "en",
+		},
+		bundle: mockBundle,
+		messageReferenceExpression: (locale) => `${locale}_greeting`,
+		settings: {
+			baseLocale: "en",
+			locales: ["fr", "de", "en", "ja"],
+		} as ProjectSettings,
+	});
+
+	expect(result.bundle.code).toContain(
+		[
+			'if (locale === "fr") return fr_greeting(inputs)',
+			'if (locale === "de") return de_greeting(inputs)',
+			'if (locale === "ja") return ja_greeting(inputs)',
+			"return en_greeting(inputs)",
+		].join("\n\t")
+	);
+});
+
 test("emits middleware locale splitting hooks when enabled", () => {
 	const mockBundle: BundleNested = {
 		id: "blue_moon_bottle",

--- a/src/compiler/compile-bundle.ts
+++ b/src/compiler/compile-bundle.ts
@@ -134,6 +134,14 @@ const compileBundleFunction = (args: {
 
 	const isFullyTranslated =
 		args.availableLocales.length === args.settings?.locales.length;
+	const baseLocale = args.settings?.baseLocale;
+	const dispatchLocales =
+		baseLocale && args.availableLocales.includes(baseLocale)
+			? [
+					...args.availableLocales.filter((locale) => locale !== baseLocale),
+					baseLocale,
+				]
+			: args.availableLocales;
 
 	const inputType = args.inputTypeAliasName;
 	const localesUnion =
@@ -151,10 +159,10 @@ const compileBundleFunction = (args: {
 		mode: "string" | "parts",
 		continuationIndent: string
 	): string =>
-		args.availableLocales
+		dispatchLocales
 			.map((locale, index) => {
 				const condition =
-					!isFullyTranslated || index < args.availableLocales.length - 1
+					!isFullyTranslated || index < dispatchLocales.length - 1
 						? `if (locale === "${locale}") `
 						: "";
 				const prefix = index > 0 ? continuationIndent : "";


### PR DESCRIPTION
## Summary

- use `baseLocale` as the final exhaustive branch in generated message functions
- preserve the configured locale order for the public locale union
- add a regression test and patch changeset

## Test plan

- `pnpm test`
- `pnpm exec oxlint src/compiler/compile-bundle.ts src/compiler/compile-bundle.test.ts`

Closes https://github.com/opral/paraglide-js/issues/724